### PR TITLE
Enhancement: Add result attributes to Network Package

### DIFF
--- a/TMGToolbox/src/common/pandas_utils.py
+++ b/TMGToolbox/src/common/pandas_utils.py
@@ -237,7 +237,7 @@ try:
                 if len(tupl) == 3: i,j, loop = tupl
                 else:
                     i,j = tupl
-                    loop = 0
+                    loop = 1
 
                 segment_indexer[(line, i, j, loop)] = pos
         segment_indexer = pd.Series(segment_indexer)

--- a/TMGToolbox/src/input_output/export_network_package.py
+++ b/TMGToolbox/src/input_output/export_network_package.py
@@ -1,4 +1,4 @@
-'''
+"""
     Copyright 2014 Travel Modelling Group, Department of Civil Engineering, University of Toronto
 
     This file is part of the TMG Toolbox.
@@ -15,130 +15,84 @@
 
     You should have received a copy of the GNU General Public License
     along with the TMG Toolbox.  If not, see <http://www.gnu.org/licenses/>.
-'''
-
-#---METADATA---------------------
-'''
-Export Network Package
-
-    Authors:Peter Kucirek, James Vaughan
-
-    Latest revision by: pkucirek
-    
-    
-    Exports a scenario as a compressed folder of files (*.nwp), which contains
-    data about modes, vehicles, base network, transit lines, link shapes, and turns.
-    Eventually this will also include extra attribute data (which is optionally
-    exported). The ratio of compression tends to be very good, since network batch
-    files are just text files. For example, a network of 18419 nodes and 46963 links
-    (with 1517 transit lines) takes less than 1MB of storage (And nearly 1GB 
-    uncompressed).
-        
-'''
-#---VERSION HISTORY
-'''
-    0.1.0 Created.
-    
-    0.2.0 Updated to optionally export extra attributes, using a custom script to update
-            the page with the available attributes for the selected scenario. This custom
-            script was written and (c) by INRO (see license notice just above the script).
-    
-    0.2.1 Removed code which supports Emme 3. A new version of this tool had been branched
-            to support the Emme 3 Modeller Beta version
-    
-    0.3.0 Change the NWP file specification. Component files, instead of using '[fileName].211'
-            (or simillar extensions) now just use one name. This allows for re-naming of the entire
-            network package without adverse effects.
-        
-    0.4.0 Major update to export database functions, to ensure no information is lost in
-            transferring networks.
-            
-    0.4.1 Minor update to check for null export file
-    
-    0.5.0 Added XTMF interface to script
-    
-    0.6.0 Added metadata file to spec (NWP Version 4.0)
-    
-    1.0.0 Switched to new versioning system. Also added searchability to extra attribute selector.
-    
-'''
+"""
 
 import inro.modeller as _m
 import traceback as _traceback
 from contextlib import contextmanager
-from contextlib import nested
 from os import path as _path
-import os as _os
 from datetime import datetime as _dt
 import shutil as _shutil
 import zipfile as _zipfile
 import tempfile as _tf
-_MODELLER = _m.Modeller() #Instantiate Modeller once.
-_util = _MODELLER.module('tmg.common.utilities')
-_tmgTPB = _MODELLER.module('tmg.common.TMG_tool_page_builder')
-_inroExportUtil = _MODELLER.module("inro.emme.utility.export_utilities")
 
-##########################################################################################################
+_MODELLER = _m.Modeller()  # Instantiate Modeller once.
+_util = _MODELLER.module('tmg.common.utilities')
+_tmg_tpb = _MODELLER.module('tmg.common.TMG_tool_page_builder')
+_inro_export_util = _MODELLER.module("inro.emme.utility.export_utilities")
+_export_modes = _MODELLER.tool('inro.emme.data.network.mode.export_modes')
+_export_vehicles = _MODELLER.tool('inro.emme.data.network.transit.export_vehicles')
+_export_base_network = _MODELLER.tool('inro.emme.data.network.base.export_base_network')
+_export_transit_lines = _MODELLER.tool('inro.emme.data.network.transit.export_transit_lines')
+_export_link_shapes = _MODELLER.tool('inro.emme.data.network.base.export_link_shape')
+_export_turns = _MODELLER.tool('inro.emme.data.network.turn.export_turns')
+_export_attributes = _MODELLER.tool('inro.emme.data.extra_attribute.export_extra_attributes')
+_export_functions = _MODELLER.tool('inro.emme.data.function.export_functions')
+
 
 class ExportNetworkPackage(_m.Tool()):
-    
     version = '1.0.0'
     tool_run_msg = ""
-    number_of_tasks = 9 # For progress reporting, enter the integer number of tasks here
-    
-    # Tool Input Parameters
-    #    Only those parameters neccessary for Modeller and/or XTMF to dock with
-    #    need to be placed here. Internal parameters (such as lists and dicts)
-    #    get intitialized during construction (__init__)
-    
-    Scenario = _m.Attribute(_m.InstanceType) # common variable or parameter
+    number_of_tasks = 9  # For progress reporting, enter the integer number of tasks here
+
+    Scenario = _m.Attribute(_m.InstanceType)
     ExportFile = _m.Attribute(str)
     ExportAllFlag = _m.Attribute(bool)
     AttributeIdsToExport = _m.Attribute(_m.ListType)
     ExportMetadata = _m.Attribute(str)
-    
+
     xtmf_AttributeIdString = _m.Attribute(str)
     xtmf_ScenarioNumber = _m.Attribute(int)
-    
+
     def __init__(self):
-        #---Init internal variables
-        self.TRACKER = _util.ProgressTracker(self.number_of_tasks) #init the ProgressTracker
-        
-        #---Set the defaults of parameters used by Modeller
-        self.Scenario = _MODELLER.scenario #Default is primary scenario
+        # Init internal variables
+        self.TRACKER = _util.ProgressTracker(self.number_of_tasks)  # init the ProgressTracker
+
+        # Set the defaults of parameters used by Modeller
+        self.Scenario = _MODELLER.scenario  # Default is primary scenario
         self.ExportMetadata = ""
-    
+
     def page(self):
-        pb = _tmgTPB.TmgToolPageBuilder(self, title="Export Network Package v%s" %self.version,
-                     description="Exports all scenario data files (modes, vehicles, nodes, \
-                                 links, transit lines, link shape, turns) to a compressed \
-                                 network package file (*.nwp).",
-                     branding_text="- TMG Toolbox")
-        
-        if self.tool_run_msg != "": # to display messages in the page
+        pb = _tmg_tpb.TmgToolPageBuilder(
+            self, title="Export Network Package v%s" % self.version,
+            description="Exports all scenario data files (modes, vehicles, nodes, links, transit lines, link shape, " +
+                        "turns) to a compressed network package file (*.nwp).",
+            branding_text="- TMG Toolbox")
+
+        if self.tool_run_msg != "":  # to display messages in the page
             pb.tool_run_status(self.tool_run_msg_status)
-            
+
         pb.add_select_scenario(tool_attribute_name='Scenario',
                                title='Scenario:',
                                allow_none=False)
-        
+
         pb.add_select_file(tool_attribute_name='ExportFile',
                            title="File name",
                            window_type='save_file',
                            file_filter="*.nwp")
 
         pb.add_checkbox(tool_attribute_name='ExportAllFlag',
-                        label= "Export all extra attributes?")
-        
-        keyval = self._GetSelectAttributeOptionsJSON()
+                        label="Export all extra attributes?")
+
+        keyval = self._get_select_attribute_options_json()
         pb.add_select(tool_attribute_name="AttributeIdsToExport", keyvalues=keyval,
-                    title="Extra Attributes", searchable= True,  
-                    note="Optional")
-        
-        pb.add_text_box(tool_attribute_name= 'ExportMetadata',
-                        size= 255, multi_line= True,
-                        title= "Export comments")
-        
+                      title="Extra Attributes", searchable=True,
+                      note="Optional")
+
+        pb.add_text_box(tool_attribute_name='ExportMetadata',
+                        size=255, multi_line=True,
+                        title="Export comments")
+
         pb.add_html("""
 <script type="text/javascript">
     $(document).ready( function ()
@@ -155,7 +109,7 @@ class ExportNetworkPackage(_m.Tool()):
             $(this).commit();
             $("#AttributeIdsToExport")
                 .empty()
-                .append(tool._GetSelectAttributeOptionsHTML())
+                .append(tool._get_select_attribute_options_html())
             inro.modeller.page.preload("#AttributeIdsToExport");
             $("#AttributeIdsToExport").trigger('change');
         });
@@ -169,270 +123,232 @@ class ExportNetworkPackage(_m.Tool()):
         });
     });
 </script>""" % pb.tool_proxy_tag)
-        
+
         return pb.render()
-    
-    ##########################################################################################################
-        
+
     def run(self):
         self.tool_run_msg = ""
         self.TRACKER.reset()
-        
-        if self.ExportFile == None:
+
+        if self.ExportFile is None:
             raise IOError("Export file not specified")
-        
+
         self.ExportFile = _path.splitext(self.ExportFile)[0] + ".nwp"
-        
+
         try:
-            self._Execute()
-        except Exception, e:
-            self.tool_run_msg = _m.PageBuilder.format_exception(
-                e, _traceback.format_exc(e))
+            self._execute()
+        except Exception as e:
+            self.tool_run_msg = _m.PageBuilder.format_exception(e, _traceback.format_exc(e))
             raise
-        
-        self.tool_run_msg = _m.PageBuilder.format_info("Done. Scenario exported to %s" %self.ExportFile)
-    
-    
-    @_m.method(return_type= bool)
+
+        self.tool_run_msg = _m.PageBuilder.format_info("Done. Scenario exported to %s" % self.ExportFile)
+
+    @_m.method(return_type=bool)
     def check_all_flag(self):
         return self.ExportAllFlag
 
     def __call__(self, xtmf_ScenarioNumber, ExportFile, xtmf_AttributeIdString):
-        
+
         self.Scenario = _m.Modeller().emmebank.scenario(xtmf_ScenarioNumber)
-        if (self.Scenario == None):
-            raise Exception("Scenario %s was not found!" %xtmf_ScenarioNumber)
-        
+        if self.Scenario is None:
+            raise Exception("Scenario %s was not found!" % xtmf_ScenarioNumber)
+
         self.ExportFile = ExportFile
         if xtmf_AttributeIdString.lower() == 'all':
-            self.ExportAllFlag = True #if true, self.AttributeIdsToExport gets set in execute
+            self.ExportAllFlag = True  # if true, self.AttributeIdsToExport gets set in execute
         else:
             cells = xtmf_AttributeIdString.split(',')
-            self.AttributeIdsToExport = [str(c.strip()) for c in cells if c.strip()] #Clean out null values
-        
+            self.AttributeIdsToExport = [str(c.strip()) for c in cells if c.strip()]  # Clean out null values
+
         try:
-            self._Execute()
+            self._execute()
         except Exception, e:
             msg = str(e) + "\n" + _traceback.format_exc(e)
             raise Exception(msg)
-    
-    ##########################################################################################################    
-    
-    
-    def _Execute(self):
-        with _m.logbook_trace(name="{classname} v{version}".format(classname=(self.__class__.__name__), version=self.version),
-                                     attributes=self._GetAtts()):
-            
-            self._CheckAttributes() #Due to the dynamic nature of the selection process, it could happen that attributes are
-                                    #selected which don't exist in the current scenario. The method checks early to catch
-                                    #any problems
-            
-            #Only need the Emme 4 namespaces of these tools
-            modeExportTool = _MODELLER.tool('inro.emme.data.network.mode.export_modes')
-            vehiclesExportTool = _MODELLER.tool('inro.emme.data.network.transit.export_vehicles')
-            baseNetworkExportTool = _MODELLER.tool('inro.emme.data.network.base.export_base_network')
-            transitExportTool = _MODELLER.tool('inro.emme.data.network.transit.export_transit_lines')
-            linkShapeExportTool = _MODELLER.tool('inro.emme.data.network.base.export_link_shape')
-            turnExportTool = _MODELLER.tool('inro.emme.data.network.turn.export_turns')
-            attributeExportTool = _MODELLER.tool('inro.emme.data.extra_attribute.export_extra_attributes')
-            functionExportTool = _MODELLER.tool('inro.emme.data.function.export_functions')
+
+    def _execute(self):
+        with _m.logbook_trace(
+                name="{classname} v{version}".format(classname=self.__class__.__name__, version=self.version),
+                attributes=self._get_logbook_attributes()):
+
+            self._check_attributes()
+            # Due to the dynamic nature of the selection process, it could happen that attributes are
+            # selected which don't exist in the current scenario. The method checks early to catch
+            # any problems
 
             if self.ExportAllFlag:
                 self.AttributeIdsToExport = [att.name for att in self.Scenario.extra_attributes()]
-            
-            with nested(self._zipFileMANAGER(), self._TempDirectoryMANAGER()) as (zf, tempFolder):
-                verionFile = tempFolder + "/version.txt"
-                with open(verionFile, 'w') as writer:
+
+            with _zipfile.ZipFile(self.ExportFile, 'w', _zipfile.ZIP_DEFLATED) as zf, self._temp_file() as temp_folder:
+                version_file = _path.join(temp_folder, "version.txt")
+                with open(version_file, 'w') as writer:
                     writer.write("4.0")
-                zf.write(verionFile, arcname="version.txt")
-                
-                infoPath = tempFolder + "/info.txt"
-                self._WriteInfoFile(infoPath)
-                zf.write(infoPath, arcname="info.txt")
-                
+                zf.write(version_file, arcname="version.txt")
+
+                info_path = _path.join(temp_folder, "info.txt")
+                self._write_info_file(info_path)
+                zf.write(info_path, arcname="info.txt")
+
                 with _m.logbook_trace("Exporting modes"):
-                    exportFile = tempFolder + "/modes.201"
-                    self.TRACKER.runTool(modeExportTool, 
-                                         export_file=exportFile,
+                    export_file = _path.join(temp_folder, "modes.201")
+                    self.TRACKER.runTool(_export_modes,
+                                         export_file=export_file,
                                          scenario=self.Scenario)
-                    zf.write(exportFile, arcname=("modes.201"))
-                
+                    zf.write(export_file, arcname="modes.201")
+
                 with _m.logbook_trace("Exporting vehicles"):
-                    exportFile = tempFolder + "/vehicles.202"
+                    export_file = _path.join(temp_folder, "vehicles.202")
                     if self.Scenario.element_totals['transit_vehicles'] == 0:
-                        self._exportBlankBatchFile(exportFile, "vehicles")
+                        self._export_blank_batch_file(export_file, "vehicles")
                         self.TRACKER.completeTask()
                     else:
-                        self.TRACKER.runTool(vehiclesExportTool,
-                                         export_file=exportFile,
-                                         scenario=self.Scenario)
-                    zf.write(exportFile, arcname=("vehicles.202"))
-                    
+                        self.TRACKER.runTool(_export_vehicles,
+                                             export_file=export_file,
+                                             scenario=self.Scenario)
+                    zf.write(export_file, arcname="vehicles.202")
+
                 with _m.logbook_trace("Exporting base network"):
-                    exportFile = tempFolder + "/base.211"                    
-                    self.TRACKER.runTool(baseNetworkExportTool,
-                                         export_file=exportFile,
+                    export_file = _path.join(temp_folder, "base.211")
+                    self.TRACKER.runTool(_export_base_network,
+                                         export_file=export_file,
                                          scenario=self.Scenario)
-                    zf.write(exportFile, arcname=("base.211"))
-                    
+                    zf.write(export_file, arcname="base.211")
+
                 with _m.logbook_trace("Exporting link shapes"):
-                    exportFile = tempFolder + "/shapes.251"
-                    self.TRACKER.runTool(linkShapeExportTool,
-                                         export_file=exportFile,
+                    export_file = _path.join(temp_folder, "shapes.251")
+                    self.TRACKER.runTool(_export_link_shapes,
+                                         export_file=export_file,
                                          scenario=self.Scenario)
-                    zf.write(exportFile, arcname=("shapes.251"))
-                
+                    zf.write(export_file, arcname="shapes.251")
+
                 with _m.logbook_trace("Exporting transit lines"):
-                    exportFile = tempFolder + "/transit.221"
+                    export_file = _path.join(temp_folder, "transit.221")
                     if self.Scenario.element_totals['transit_lines'] == 0:
-                        self._exportBlankBatchFile(exportFile, "lines")
+                        self._export_blank_batch_file(export_file, "lines")
                         self.TRACKER.completeTask()
                     else:
-                        self.TRACKER.runTool(transitExportTool,
-                                             export_file=exportFile,
+                        self.TRACKER.runTool(_export_transit_lines,
+                                             export_file=export_file,
                                              scenario=self.Scenario)
-                        
-                    zf.write(exportFile, arcname=("transit.221"))
-                
+
+                    zf.write(export_file, arcname="transit.221")
+
                 with _m.logbook_trace("Exporting turns"):
-                    exportFile = tempFolder + "/turns.231"
+                    export_file = _path.join(temp_folder, "turns.231")
                     if self.Scenario.element_totals['turns'] == 0:
-                        self._exportBlankBatchFile(exportFile, "turns")
+                        self._export_blank_batch_file(export_file, "turns")
                         self.TRACKER.completeTask()
                     else:
-                        self.TRACKER.runTool(turnExportTool,
-                                             export_file=exportFile,
+                        self.TRACKER.runTool(_export_turns,
+                                             export_file=export_file,
                                              scenario=self.Scenario)
-                        
-                    zf.write(exportFile, arcname=("turns.231"))
-                
+
+                    zf.write(export_file, arcname="turns.231")
+
                 with _m.logbook_trace("Exporting Functions"):
-                    exportFile = tempFolder + "/functions.411"
-                    self.TRACKER.runTool(functionExportTool,
-                                         export_file=exportFile)
-                    zf.write(exportFile, arcname=("functions.411"))
-                
+                    export_file = _path.join(temp_folder, "functions.411")
+                    self.TRACKER.runTool(_export_functions,
+                                         export_file=export_file)
+                    zf.write(export_file, arcname="functions.411")
+
                 if len(self.AttributeIdsToExport) > 0:
                     with _m.logbook_trace("Exporting extra attributes"):
-                        _m.logbook_write("List of attributes: %s" %self.AttributeIdsToExport)
-                        
-                        extraAttributes = [self.Scenario.extra_attribute(id) for id in self.AttributeIdsToExport]
-                        typeSet = set([att.type.lower() for att in extraAttributes])
-                        
-                        self.TRACKER.runTool(attributeExportTool, extraAttributes,
-                                            tempFolder,
-                                            field_separator=',',
-                                            scenario=self.Scenario)
-                        for t in typeSet:
+                        _m.logbook_write("List of attributes: %s" % self.AttributeIdsToExport)
+
+                        extra_attributes = [self.Scenario.extra_attribute(id_) for id_ in self.AttributeIdsToExport]
+                        types = set([att.type.lower() for att in extra_attributes])
+
+                        self.TRACKER.runTool(_export_attributes, extra_attributes,
+                                             temp_folder,
+                                             field_separator=',',
+                                             scenario=self.Scenario)
+                        for t in types:
                             if t == 'transit_segment':
                                 t = 'segment'
-                            filename = tempFolder + "/extra_%ss_%s.csv" %(t, self.Scenario.number)
-                            zf.write(filename, arcname="exatt_%ss.241" %t)
-                            #_os.remove(filename)
-                        
-                        summaryFile = tempFolder + "/exatts.241"
-                        self._ExportAttributeDefinitionFile(summaryFile, extraAttributes)
-                        zf.write(summaryFile, arcname=_path.basename("exatts.241"))
-                        #_os.remove(summaryFile)
+                            filename = temp_folder + "/extra_%ss_%s.csv" % (t, self.Scenario.number)
+                            zf.write(filename, arcname="exatt_%ss.241" % t)
+
+                        summary_file = _path.join(temp_folder, "exatts.241")
+                        self._export_attribute_definition_file(summary_file, extra_attributes)
+                        zf.write(summary_file, arcname=_path.basename("exatts.241"))
                 else:
                     self.TRACKER.completeTask()
-                
 
-    ##########################################################################################################
-    #----CONTEXT MANAGERS---------------------------------------------------------------------------------
-    '''
-    Context managers for temporary database modifications.
-    '''
-    
     @contextmanager
-    def _zipFileMANAGER(self):
-        zf = _zipfile.ZipFile(self.ExportFile, 'w', _zipfile.ZIP_DEFLATED)
-        try:
-            yield zf
-        finally:
-            zf.close()
-    
-    @contextmanager
-    def _TempDirectoryMANAGER(self):
+    def _temp_file(self):
         foldername = _tf.mkdtemp()
-        _m.logbook_write("Created temporary directory at '%s'" %foldername)
+        _m.logbook_write("Created temporary directory at '%s'" % foldername)
         try:
             yield foldername
         finally:
             _shutil.rmtree(foldername, True)
-            #_os.removedirs(foldername)
-            _m.logbook_write("Deleted temporary directory at '%s'" %foldername)
-    
-    #----SUB FUNCTIONS---------------------------------------------------------------------------------  
-    
-    def _GetAtts(self):
-        atts = {
-                "Scenario" : str(self.Scenario.id),
-                "Export File": _path.splitext(self.ExportFile)[0], 
-                "Version": self.version, 
-                "self": self.__MODELLER_NAMESPACE__}
-            
-        return atts
-    
-    def _CheckAttributes(self):
-        definedAttributes = [att.name for att in self.Scenario.extra_attributes()]
-        for attName in self.AttributeIdsToExport:
-            if not attName in definedAttributes:
-                raise IOError("Attribute '%s' not defined in scenario %s" %(attName, self.Scenario.number))
-    
-    def _exportBlankBatchFile(self, filename, tRecord):
-        with open(filename, 'w') as file:
-            file.write("t %s init" %tRecord)
+            _m.logbook_write("Deleted temporary directory at '%s'" % foldername)
 
-    def _ExportAttributeDefinitionFile(self, filename, attList):
+    def _get_logbook_attributes(self):
+        atts = {
+            "Scenario": str(self.Scenario.id),
+            "Export File": _path.splitext(self.ExportFile)[0],
+            "Version": self.version,
+            "self": self.__MODELLER_NAMESPACE__}
+
+        return atts
+
+    def _check_attributes(self):
+        defined_attributes = [att.name for att in self.Scenario.extra_attributes()]
+        for attribute_id in self.AttributeIdsToExport:
+            if attribute_id not in defined_attributes:
+                raise IOError("Attribute '%s' not defined in scenario %s" % (attribute_id, self.Scenario.number))
+
+    @staticmethod
+    def _export_blank_batch_file(filename, t_record):
+        with open(filename, 'w') as file_:
+            file_.write("t %s init" % t_record)
+
+    @staticmethod
+    def _export_attribute_definition_file(filename, attribute_list):
         with open(filename, 'w') as writer:
             writer.write("name,type, default")
-            for att in attList:
-                writer.write("\n{name},{type},{default},'{desc}'"\
-                             .format(name=att.name,
-                                     type=att.type,
-                                     default=att.default_value,
-                                     desc=att.description))
-    
-    def _WriteInfoFile(self, path):
+            for att in attribute_list:
+                writer.write("\n{name},{type},{default},'{desc}'".format(
+                    name=att.name, type=att.type, default=att.default_value, desc=att.description
+                ))
+
+    def _write_info_file(self, path):
         with open(path, 'w') as writer:
             bank = _MODELLER.emmebank
             time = _dt.now()
             lines = [str(bank.title),
                      str(bank.path),
-                     "%s - %s" %(self.Scenario, self.Scenario.title),
-                     "{y}-{m}-{d} {h}:{mm}".format(y= time.year, m= time.month, d= time.day,
-                                                   h= time.hour, mm= time.minute),
+                     "%s - %s" % (self.Scenario, self.Scenario.title),
+                     "{y}-{m}-{d} {h}:{mm}".format(y=time.year, m=time.month, d=time.day,
+                                                   h=time.hour, mm=time.minute),
                      self.ExportMetadata]
-            
+
             writer.write("\n".join(lines))
-    
-    def _GetSelectAttributeOptionsJSON(self):
+
+    def _get_select_attribute_options_json(self):
         keyval = {}
-        
+
         for att in self.Scenario.extra_attributes():
             label = "{id} ({domain}) - {name}".format(id=att.name, domain=att.type, name=att.description)
             keyval[att.name] = label
-        
+
         return keyval
-    
+
     @_m.method(return_type=unicode)
-    def _GetSelectAttributeOptionsHTML(self):
-        list = []
-        
+    def _get_select_attribute_options_html(self):
+        list_ = []
+
         for att in self.Scenario.extra_attributes():
             label = "{id} ({domain}) - {name}".format(id=att.name, domain=att.type, name=att.description)
             html = unicode('<option value="{id}">{text}</option>'.format(id=att.name, text=label))
-            list.append(html)
-        return "\n".join(list)
-    
+            list_.append(html)
+        return "\n".join(list_)
+
     @_m.method(return_type=_m.TupleType)
     def percent_completed(self):
         return self.TRACKER.getProgress()
-                
+
     @_m.method(return_type=unicode)
     def tool_run_msg_status(self):
         return self.tool_run_msg
-    
-
-    

--- a/TMGToolbox/src/input_output/export_network_package.py
+++ b/TMGToolbox/src/input_output/export_network_package.py
@@ -189,90 +189,108 @@ class ExportNetworkPackage(_m.Tool()):
                 self._write_info_file(info_path)
                 zf.write(info_path, arcname="info.txt")
 
-                with _m.logbook_trace("Exporting modes"):
-                    export_file = _path.join(temp_folder, "modes.201")
-                    self.TRACKER.runTool(_export_modes,
-                                         export_file=export_file,
-                                         scenario=self.Scenario)
-                    zf.write(export_file, arcname="modes.201")
-
-                with _m.logbook_trace("Exporting vehicles"):
-                    export_file = _path.join(temp_folder, "vehicles.202")
-                    if self.Scenario.element_totals['transit_vehicles'] == 0:
-                        self._export_blank_batch_file(export_file, "vehicles")
-                        self.TRACKER.completeTask()
-                    else:
-                        self.TRACKER.runTool(_export_vehicles,
-                                             export_file=export_file,
-                                             scenario=self.Scenario)
-                    zf.write(export_file, arcname="vehicles.202")
-
-                with _m.logbook_trace("Exporting base network"):
-                    export_file = _path.join(temp_folder, "base.211")
-                    self.TRACKER.runTool(_export_base_network,
-                                         export_file=export_file,
-                                         scenario=self.Scenario)
-                    zf.write(export_file, arcname="base.211")
-
-                with _m.logbook_trace("Exporting link shapes"):
-                    export_file = _path.join(temp_folder, "shapes.251")
-                    self.TRACKER.runTool(_export_link_shapes,
-                                         export_file=export_file,
-                                         scenario=self.Scenario)
-                    zf.write(export_file, arcname="shapes.251")
-
-                with _m.logbook_trace("Exporting transit lines"):
-                    export_file = _path.join(temp_folder, "transit.221")
-                    if self.Scenario.element_totals['transit_lines'] == 0:
-                        self._export_blank_batch_file(export_file, "lines")
-                        self.TRACKER.completeTask()
-                    else:
-                        self.TRACKER.runTool(_export_transit_lines,
-                                             export_file=export_file,
-                                             scenario=self.Scenario)
-
-                    zf.write(export_file, arcname="transit.221")
-
-                with _m.logbook_trace("Exporting turns"):
-                    export_file = _path.join(temp_folder, "turns.231")
-                    if self.Scenario.element_totals['turns'] == 0:
-                        self._export_blank_batch_file(export_file, "turns")
-                        self.TRACKER.completeTask()
-                    else:
-                        self.TRACKER.runTool(_export_turns,
-                                             export_file=export_file,
-                                             scenario=self.Scenario)
-
-                    zf.write(export_file, arcname="turns.231")
-
-                with _m.logbook_trace("Exporting Functions"):
-                    export_file = _path.join(temp_folder, "functions.411")
-                    self.TRACKER.runTool(_export_functions,
-                                         export_file=export_file)
-                    zf.write(export_file, arcname="functions.411")
+                self._batchout_modes(temp_folder, zf)
+                self._batchout_vehicles(temp_folder, zf)
+                self._batchout_base(temp_folder, zf)
+                self._batchout_shapes(temp_folder, zf)
+                self._batchout_lines(temp_folder, zf)
+                self._batchout_turns(temp_folder, zf)
+                self._batchout_functions(temp_folder, zf)
 
                 if len(self.AttributeIdsToExport) > 0:
-                    with _m.logbook_trace("Exporting extra attributes"):
-                        _m.logbook_write("List of attributes: %s" % self.AttributeIdsToExport)
-
-                        extra_attributes = [self.Scenario.extra_attribute(id_) for id_ in self.AttributeIdsToExport]
-                        types = set([att.type.lower() for att in extra_attributes])
-
-                        self.TRACKER.runTool(_export_attributes, extra_attributes,
-                                             temp_folder,
-                                             field_separator=',',
-                                             scenario=self.Scenario)
-                        for t in types:
-                            if t == 'transit_segment':
-                                t = 'segment'
-                            filename = temp_folder + "/extra_%ss_%s.csv" % (t, self.Scenario.number)
-                            zf.write(filename, arcname="exatt_%ss.241" % t)
-
-                        summary_file = _path.join(temp_folder, "exatts.241")
-                        self._export_attribute_definition_file(summary_file, extra_attributes)
-                        zf.write(summary_file, arcname=_path.basename("exatts.241"))
+                    self._batchout_extra_attributes(temp_folder, zf)
                 else:
                     self.TRACKER.completeTask()
+
+    @_m.logbook_trace("Exporting modes")
+    def _batchout_modes(self, temp_folder, zf):
+        export_file = _path.join(temp_folder, "modes.201")
+        self.TRACKER.runTool(_export_modes,
+                             export_file=export_file,
+                             scenario=self.Scenario)
+        zf.write(export_file, arcname="modes.201")
+
+    @_m.logbook_trace("Exporting vehicles")
+    def _batchout_vehicles(self, temp_folder, zf):
+        export_file = _path.join(temp_folder, "vehicles.202")
+        if self.Scenario.element_totals['transit_vehicles'] == 0:
+            self._export_blank_batch_file(export_file, "vehicles")
+            self.TRACKER.completeTask()
+        else:
+            self.TRACKER.runTool(_export_vehicles,
+                                 export_file=export_file,
+                                 scenario=self.Scenario)
+        zf.write(export_file, arcname="vehicles.202")
+
+    @_m.logbook_trace("Exporting base network")
+    def _batchout_base(self, temp_folder, zf):
+        export_file = _path.join(temp_folder, "base.211")
+        self.TRACKER.runTool(_export_base_network,
+                             export_file=export_file,
+                             scenario=self.Scenario)
+        zf.write(export_file, arcname="base.211")
+
+    @_m.logbook_trace("Exporting link shapes")
+    def _batchout_shapes(self, temp_folder, zf):
+        export_file = _path.join(temp_folder, "shapes.251")
+        self.TRACKER.runTool(_export_link_shapes,
+                             export_file=export_file,
+                             scenario=self.Scenario)
+        zf.write(export_file, arcname="shapes.251")
+
+    @_m.logbook_trace("Exporting transit lines")
+    def _batchout_lines(self, temp_folder, zf):
+        export_file = _path.join(temp_folder, "transit.221")
+        if self.Scenario.element_totals['transit_lines'] == 0:
+            self._export_blank_batch_file(export_file, "lines")
+            self.TRACKER.completeTask()
+        else:
+            self.TRACKER.runTool(_export_transit_lines,
+                                 export_file=export_file,
+                                 scenario=self.Scenario)
+
+        zf.write(export_file, arcname="transit.221")
+
+    @_m.logbook_trace("Exporting turns")
+    def _batchout_turns(self, temp_folder, zf):
+        export_file = _path.join(temp_folder, "turns.231")
+        if self.Scenario.element_totals['turns'] == 0:
+            self._export_blank_batch_file(export_file, "turns")
+            self.TRACKER.completeTask()
+        else:
+            self.TRACKER.runTool(_export_turns,
+                                 export_file=export_file,
+                                 scenario=self.Scenario)
+
+        zf.write(export_file, arcname="turns.231")
+
+    @_m.logbook_trace("Exporting Functions")
+    def _batchout_functions(self, temp_folder, zf):
+        export_file = _path.join(temp_folder, "functions.411")
+        self.TRACKER.runTool(_export_functions,
+                             export_file=export_file)
+        zf.write(export_file, arcname="functions.411")
+
+    @_m.logbook_trace("Exporting extra attributes")
+    def _batchout_extra_attributes(self, temp_folder, zf):
+        _m.logbook_write("List of attributes: %s" % self.AttributeIdsToExport)
+
+        extra_attributes = [self.Scenario.extra_attribute(id_) for id_ in self.AttributeIdsToExport]
+        types = set([att.type.lower() for att in extra_attributes])
+
+        self.TRACKER.runTool(_export_attributes, extra_attributes,
+                             temp_folder,
+                             field_separator=',',
+                             scenario=self.Scenario)
+        for t in types:
+            if t == 'transit_segment':
+                t = 'segment'
+            filename = _path.join(temp_folder, "extra_%ss_%s.csv" % (t, self.Scenario.number))
+            zf.write(filename, arcname="exatt_%ss.241" % t)
+
+        summary_file = _path.join(temp_folder, "exatts.241")
+        self._export_attribute_definition_file(summary_file, extra_attributes)
+        zf.write(summary_file, arcname="exatts.241")
 
     @contextmanager
     def _temp_file(self):

--- a/TMGToolbox/src/input_output/import_network_package.py
+++ b/TMGToolbox/src/input_output/import_network_package.py
@@ -1,4 +1,4 @@
-'''
+"""
     Copyright 2014 Travel Modelling Group, Department of Civil Engineering, University of Toronto
 
     This file is part of the TMG Toolbox.
@@ -15,122 +15,74 @@
 
     You should have received a copy of the GNU General Public License
     along with the TMG Toolbox.  If not, see <http://www.gnu.org/licenses/>.
-'''
-
-#---METADATA---------------------
-'''
-Import Network Package
-
-    Authors: Peter Kucirek
- 
-    Latest revision by: pkucirek 
-    
-    
-    Imports a compressed network package file.
-        
-'''
-#---VERSION HISTORY
-'''
-    0.1.0 Created
-    
-    0.2.0 Added the ability to read in exported extra attributes
-    
-    0.2.1 Set up small javascript to suggest a scenario description based on the network
-            package file name
-    
-    0.2.2 Removed code which supports Emme 3. A new version of this tool had been branched
-            to support the Emme 3 Modeller Beta version
-            
-    0.3.0 Major update to support NWP V2.0 format. Tool still supports old format, including renamed
-            NWP files
-            
-    0.4.0 Major update to support NWP V3.0 format, which includes database functions. This tool calls on
-        TMG2.IO.MergeFunctions to merge in a functions file.
-        
-    0.4.1 Minor update to check for null export file
-    
-    0.5.0 Added XTMF interface to script
-    
-    0.6.0 Added loading of NWP metadata (info.txt) which is new (NWP Version 4.0 +)
-    
-    0.6.1 Tweaked the look of the metadata table. Also updated the file browser to not
-            always start in the project Database folder.
-    
-    1.0.0 Updated to better version numbering system. From here on out, the first digit
-            is a major version (i.e. a breaking change), the second digit is for new
-            features, and the last digit is for bug fixes. 
-            
-            Also added a feature to better handle scenarios, since Emme uses 5-digit
-            scenario numbers (regardless of how many scenarios are actually defined
-            in the Emmebank).
-    
-    1.1.0 Improved the way function conflicts are handled. Now, options are given to 
-            the MergeFunctions tool to handle.
-    
-'''
+"""
 
 import inro.modeller as _m
 import traceback as _traceback
 from contextlib import contextmanager
-from contextlib import nested
 import zipfile as _zipfile
 from os import path as _path
-import os as _os
 import shutil as _shutil
 import tempfile as _tf
-_MODELLER = _m.Modeller() #Instantiate Modeller once.
+
+_MODELLER = _m.Modeller()  # Instantiate Modeller once.
 _bank = _MODELLER.emmebank
 _util = _MODELLER.module('tmg.common.utilities')
-_tmgTPB = _MODELLER.module('tmg.common.TMG_tool_page_builder')
-mergeFunctionsTool = _MODELLER.tool('tmg.input_output.merge_functions')
+_tmg_tpb = _MODELLER.module('tmg.common.TMG_tool_page_builder')
+merge_functions = _MODELLER.tool('tmg.input_output.merge_functions')
+import_modes = _MODELLER.tool('inro.emme.data.network.mode.mode_transaction')
+import_vehicles = _MODELLER.tool('inro.emme.data.network.transit.vehicle_transaction')
+import_base = _MODELLER.tool('inro.emme.data.network.base.base_network_transaction')
+import_link_shape = _MODELLER.tool('inro.emme.data.network.base.link_shape_transaction')
+import_lines = _MODELLER.tool('inro.emme.data.network.transit.transit_line_transaction')
+import_turns = _MODELLER.tool('inro.emme.data.network.turn.turn_transaction')
+import_attributes = _MODELLER.tool('inro.emme.data.network.import_attribute_values')
 
-##########################################################################################################
 
 class ImportNetworkPackage(_m.Tool()):
-    
     version = '1.1.0'
     tool_run_msg = ""
-    number_of_tasks = 9 # For progress reporting, enter the integer number of tasks here
-    
+    number_of_tasks = 9  # For progress reporting, enter the integer number of tasks here
+
     __components = ['modes.201', 'vehicles.202', 'base.211', 'transit.221', 'turns.231', 'shapes.251']
-    
+
     # Tool Input Parameters
     #    Only those parameters neccessary for Modeller and/or XTMF to dock with
     #    need to be placed here. Internal parameters (such as lists and dicts)
     #    get intitialized during construction (__init__)
-    
-    ScenarioId = _m.Attribute(int) # common variable or parameter
+
+    ScenarioId = _m.Attribute(int)  # common variable or parameter
     NetworkPackageFile = _m.Attribute(str)
     ScenarioDescription = _m.Attribute(str)
     OverwriteScenarioFlag = _m.Attribute(bool)
     ConflictOption = _m.Attribute(str)
-    
+
     def __init__(self):
-        #---Init internal variables
-        self.TRACKER = _util.ProgressTracker(self.number_of_tasks) #init the ProgressTracker
-        
-        #---Set the defaults of parameters used by Modeller
+        # ---Init internal variables
+        self.TRACKER = _util.ProgressTracker(self.number_of_tasks)  # init the ProgressTracker
+
+        # ---Set the defaults of parameters used by Modeller
         self.ScenarioDescription = ""
         self.OverwriteScenarioFlag = False
-        self.ConflictOption = mergeFunctionsTool.EDIT_OPTION
-    
+        self.ConflictOption = merge_functions.EDIT_OPTION
+
     def page(self):
-        pb = _tmgTPB.TmgToolPageBuilder(self, title="Import Network Package v%s" %self.version,
-                     description="Imports a new scenario from a compressed network package \
+        pb = _tmg_tpb.TmgToolPageBuilder(self, title="Import Network Package v%s" % self.version,
+                                         description="Imports a new scenario from a compressed network package \
                              (*.nwp) file.",
-                     branding_text="- TMG Toolbox")
-        
-        if self.tool_run_msg != "": # to display messages in the page
+                                         branding_text="- TMG Toolbox")
+
+        if self.tool_run_msg != "":  # to display messages in the page
             pb.tool_run_status(self.tool_run_msg_status)
-        
+
         pb.add_select_file(tool_attribute_name='NetworkPackageFile',
                            window_type='file',
                            title="Network Package File",
                            file_filter='*.nwp')
-        
+
         pb.add_html("""<div class="t_element" id="NetworkPackageInfoDiv" style="padding: 0px inherit;">
         </div>""")
-        
+
         pb.add_text_box(tool_attribute_name='ScenarioId',
                         size=4,
                         title="New Scenario Number",
@@ -140,18 +92,18 @@ class ImportNetworkPackage(_m.Tool()):
                                   title="New Scenario Number",
                                   note="'Next' picks the next available scenario.")
         '''
-        
+
         pb.add_text_box(tool_attribute_name='ScenarioDescription',
                         size=60,
                         title="Scenario description")
-        
-        pb.add_select(tool_attribute_name= 'ConflictOption',
-                      keyvalues= mergeFunctionsTool.OPTIONS_LIST,
-                      title= "Function Conflict Option",
-                      note= "Select an action to take if there are conflicts found \
+
+        pb.add_select(tool_attribute_name='ConflictOption',
+                      keyvalues=merge_functions.OPTIONS_LIST,
+                      title="Function Conflict Option",
+                      note="Select an action to take if there are conflicts found \
                       between the package and the current Emmebank.")
-                
-        #---JAVASCRIPT
+
+        # ---JAVASCRIPT
         pb.add_html("""
 <script type="text/javascript">
     $(document).ready( function ()
@@ -212,248 +164,213 @@ class ImportNetworkPackage(_m.Tool()):
         $("#ScenarioId").trigger('change');
     });
 </script>""" % pb.tool_proxy_tag)
-        
+
         return pb.render()
-    
-    ##########################################################################################################
-        
+
     def run(self):
         self.tool_run_msg = ""
         self.TRACKER.reset()
-        
+
         if self.ScenarioId < 1:
-            raise Exception("Scenario '%s' is not a valid scenario" %self.ScenarioId)
-        
-        if self.NetworkPackageFile == None:
+            raise Exception("Scenario '%s' is not a valid scenario" % self.ScenarioId)
+
+        if self.NetworkPackageFile is None:
             raise IOError("Import file not specified")
-        
+
         try:
-            self._Execute()
-        except Exception, e:
-            self.tool_run_msg = _m.PageBuilder.format_exception(
-                e, _traceback.format_exc(e))
+            self._execute()
+        except Exception as e:
+            self.tool_run_msg = _m.PageBuilder.format_exception(e, _traceback.format_exc(e))
             raise
-        
-        self.tool_run_msg = _m.PageBuilder.format_info("Done. Scenario %s created." %self.ScenarioId)
-    
-    
+
+        self.tool_run_msg = _m.PageBuilder.format_info("Done. Scenario %s created." % self.ScenarioId)
+
     def __call__(self, NetworkPackageFile, ScenarioId, ConflictOption):
-        
+
         self.NetworkPackageFile = NetworkPackageFile
         self.ScenarioDescription = ""
         self.ScenarioId = ScenarioId
         self.OverwriteScenarioFlag = True
         self.ConflictOption = ConflictOption
-        
+
         try:
-            self._Execute()
+            self._execute()
         except Exception, e:
             msg = str(e) + "\n" + _traceback.format_exc(e)
             raise Exception(msg)
-    
-    ##########################################################################################################    
-    
-    
-    def _Execute(self):
-        with _m.logbook_trace(name="{classname} v{version}".format(classname=(self.__class__.__name__), version=self.version),
-                                     attributes=self._GetAtts()):
-            
-            if _bank.scenario(self.ScenarioId) != None and not self.OverwriteScenarioFlag:
-                raise IOError("Scenario %s exists and overwrite flag is set to false." %self.ScenarioId)
-            
-            importModeTool = _MODELLER.tool('inro.emme.data.network.mode.mode_transaction')
-            importVehicleTool = _MODELLER.tool('inro.emme.data.network.transit.vehicle_transaction')
-            importBaseNetworkTool = _MODELLER.tool('inro.emme.data.network.base.base_network_transaction')
-            importLinkShapeTool = _MODELLER.tool('inro.emme.data.network.base.link_shape_transaction')
-            importTransitTool = _MODELLER.tool('inro.emme.data.network.transit.transit_line_transaction')
-            importTurnTool = _MODELLER.tool('inro.emme.data.network.turn.turn_transaction')
-            importAttributesTool = _MODELLER.tool('inro.emme.data.network.import_attribute_values')
-            
-            with nested(self._zipFileMANAGER(), self._TempDirectoryMANAGER()) as (zf, tempFolder):
-                
-                version = self._CheckNetworkPackage(zf) #Check the file format.
-                
-                baseName = _path.splitext(_path.basename(self.NetworkPackageFile))[0] # Get the base name for file contents
-                
-                if _bank.scenario(self.ScenarioId) != None:
+
+    def _execute(self):
+        with _m.logbook_trace(
+                name="{classname} v{version}".format(classname=self.__class__.__name__, version=self.version),
+                attributes=self._get_logbook_attributes()):
+
+            if _bank.scenario(self.ScenarioId) is not None and not self.OverwriteScenarioFlag:
+                raise IOError("Scenario %s exists and overwrite flag is set to false." % self.ScenarioId)
+
+            with _zipfile.ZipFile(self.NetworkPackageFile) as zf, self._temp_file() as temp_folder:
+
+                self._check_network_package(zf)  # Check the file format.
+
+                if _bank.scenario(self.ScenarioId) is not None:
                     if not self.OverwriteScenarioFlag:
-                        raise IOError("Scenario %s already exists." %self.ScenarioId)
+                        raise IOError("Scenario %s already exists." % self.ScenarioId)
                     sc = _bank.scenario(self.ScenarioId)
                     if sc.modify_protected or sc.delete_protected:
-                        raise IOError("Scenario %s is protected against modifications" %self.ScenarioId)
+                        raise IOError("Scenario %s is protected against modifications" % self.ScenarioId)
                     _bank.delete_scenario(self.ScenarioId)
                 scenario = _bank.create_scenario(self.ScenarioId)
                 scenario.title = self.ScenarioDescription
-                
-                _m.logbook_write("Created new scenario %s" %self.ScenarioId)
+
+                _m.logbook_write("Created new scenario %s" % self.ScenarioId)
                 self.TRACKER.completeTask()
-                
+
                 with _m.logbook_trace("Reading modes"):
-                    zf.extract(self.__components[0], tempFolder)
-                    self.TRACKER.runTool(importModeTool,
-                                         transaction_file="%s/%s" %(tempFolder, self.__components[0]),
+                    zf.extract(self.__components[0], temp_folder)
+                    self.TRACKER.runTool(import_modes,
+                                         transaction_file="%s/%s" % (temp_folder, self.__components[0]),
                                          scenario=scenario)
-                
+
                 with _m.logbook_trace("Reading vehicles"):
-                    zf.extract(self.__components[1], tempFolder)
-                    self.TRACKER.runTool(importVehicleTool,
-                                         transaction_file="%s/%s" %(tempFolder, self.__components[1]),
+                    zf.extract(self.__components[1], temp_folder)
+                    self.TRACKER.runTool(import_vehicles,
+                                         transaction_file="%s/%s" % (temp_folder, self.__components[1]),
                                          scenario=scenario)
-                
+
                 with _m.logbook_trace("Reading base network"):
-                    zf.extract(self.__components[2], tempFolder)
-                    self.TRACKER.runTool(importBaseNetworkTool,
-                                         transaction_file="%s/%s" %(tempFolder, self.__components[2]),
+                    zf.extract(self.__components[2], temp_folder)
+                    self.TRACKER.runTool(import_base,
+                                         transaction_file="%s/%s" % (temp_folder, self.__components[2]),
                                          scenario=scenario)
-                
+
                 with _m.logbook_trace("Reading link shapes"):
-                    zf.extract(self.__components[5], tempFolder)
-                    self.TRACKER.runTool(importLinkShapeTool,
-                                         transaction_file="%s/%s" %(tempFolder, self.__components[5]),
+                    zf.extract(self.__components[5], temp_folder)
+                    self.TRACKER.runTool(import_link_shape,
+                                         transaction_file="%s/%s" % (temp_folder, self.__components[5]),
                                          scenario=scenario)
-                    
+
                 with _m.logbook_trace("Reading transit lines"):
-                    zf.extract(self.__components[3], tempFolder)
-                    self.TRACKER.runTool(importTransitTool,
-                                         transaction_file="%s/%s" %(tempFolder, self.__components[3]),
+                    zf.extract(self.__components[3], temp_folder)
+                    self.TRACKER.runTool(import_lines,
+                                         transaction_file="%s/%s" % (temp_folder, self.__components[3]),
                                          scenario=scenario)
-                
+
                 with _m.logbook_trace("Reading turns"):
-                    zf.extract(self.__components[4], tempFolder)
-                    self.TRACKER.runTool(importTurnTool,
-                                         transaction_file="%s/%s" %(tempFolder, self.__components[4]),
+                    zf.extract(self.__components[4], temp_folder)
+                    self.TRACKER.runTool(import_turns,
+                                         transaction_file="%s/%s" % (temp_folder, self.__components[4]),
                                          scenario=scenario)
-                
+
                 if "exatts.241" in zf.namelist():
                     with _m.logbook_trace("Reading extra attributes"):
-                        typeSet = self._LoadExtraAttributes(zf, tempFolder, scenario)
-                        
-                        self.TRACKER.startProcess(len(typeSet))
-                        for t in typeSet:
-                            filename = "exatt_%ss.241" %t.lower()
+                        types = self._load_extra_attributes(zf, temp_folder, scenario)
+
+                        self.TRACKER.startProcess(len(types))
+                        for t in types:
+                            filename = "exatt_%ss.241" % t.lower()
                             if t == "TRANSIT_SEGMENT":
                                 filename = "exatt_segments.241"
-                            
-                            zf.extract(filename, tempFolder)
-                            importAttributesTool(file_path="%s/%s" %(tempFolder, filename),
-                                                 field_separator=",",
-                                                 scenario=scenario)
+
+                            zf.extract(filename, temp_folder)
+                            import_attributes(file_path="%s/%s" % (temp_folder, filename),
+                                              field_separator=",",
+                                              scenario=scenario)
                             self.TRACKER.completeSubtask()
                 self.TRACKER.completeTask()
-                
-                if "functions.411" in self.__components:       
-                    zf.extract(self.__components[6], tempFolder)
-                    mergeFunctionsTool.FunctionFile = "%s/%s" %(tempFolder, self.__components[6])
-                    mergeFunctionsTool.ConflictOption = self.ConflictOption
-                    mergeFunctionsTool.run()
+
+                if "functions.411" in self.__components:
+                    zf.extract(self.__components[6], temp_folder)
+                    merge_functions.FunctionFile = "%s/%s" % (temp_folder, self.__components[6])
+                    merge_functions.ConflictOption = self.ConflictOption
+                    merge_functions.run()
                 self.TRACKER.completeTask()
-                        
 
-    ##########################################################################################################
-
-    #----CONTEXT MANAGERS---------------------------------------------------------------------------------
-    '''
-    Context managers for temporary database modifications.
-    '''
-    
     @contextmanager
-    def _zipFileMANAGER(self):
-        # Code here is executed upon entry {
-        zf = _zipfile.ZipFile(self.NetworkPackageFile)
-        # }
-        try:
-            yield zf
-        finally:
-            zf.close()
-    
-    @contextmanager
-    def _TempDirectoryMANAGER(self):
+    def _temp_file(self):
         foldername = _tf.mkdtemp()
-        _m.logbook_write("Created temporary directory at '%s'" %foldername)
+        _m.logbook_write("Created temporary directory at '%s'" % foldername)
         try:
             yield foldername
         finally:
             _shutil.rmtree(foldername, True)
-            #_os.removedirs(foldername)
-            _m.logbook_write("Deleted temporary directory at '%s'" %foldername)
-    
-    #----SUB FUNCTIONS---------------------------------------------------------------------------------  
-    
-    def _CheckNetworkPackage(self, package):
+            _m.logbook_write("Deleted temporary directory at '%s'" % foldername)
+
+    def _check_network_package(self, package):
+        """"""
+
         '''
         This method reads the NWP's version number and sets up the list of
         component files to extract. It also handles backwards compatibility.
         '''
-        
+
         contents = package.namelist()
         if 'version.txt' in contents:
             self.__components = ['modes.201', 'vehicles.202', 'base.211', 'transit.221', 'turns.231', 'shapes.251']
-            
+
             vf = package.open('version.txt')
             version = float(vf.readline())
-            
+
             if version >= 3:
                 self.__components.append('functions.411')
-            
+
             return version
-        
-        renumberCount = 0
+
+        renumber_count = 0
         for component in contents:
             if component.endswith(".201"):
                 self.__components[0] = component
-                renumberCount += 1
+                renumber_count += 1
             elif component.endswith(".202"):
                 self.__components[1] = component
-                renumberCount += 1
+                renumber_count += 1
             elif component.endswith(".211"):
                 self.__components[2] = component
-                renumberCount += 1
+                renumber_count += 1
             elif component.endswith(".221"):
                 self.__components[3] = component
-                renumberCount += 1
+                renumber_count += 1
             elif component.endswith(".231"):
                 self.__components[4] = component
-                renumberCount += 1
+                renumber_count += 1
             elif component.endswith(".251"):
                 self.__components[5] = component
-                renumberCount += 1
-        if renumberCount != 6:
+                renumber_count += 1
+        if renumber_count != 6:
             raise IOError("File appears to be missing some components. Please contact TMG for assistance.")
-        
+
         return 1.0
-    
-    def _GetAtts(self):
+
+    def _get_logbook_attributes(self):
         atts = {
-                "Scenario" : self.ScenarioId,
-                "Import File": self.NetworkPackageFile, 
-                "Version": self.version, 
-                "self": self.__MODELLER_NAMESPACE__}
-            
+            "Scenario": self.ScenarioId,
+            "Import File": self.NetworkPackageFile,
+            "Version": self.version,
+            "self": self.__MODELLER_NAMESPACE__}
+
         return atts
-    
-    def _LoadExtraAttributes(self, zf, tempFolder, scenario):
-        zf.extract("exatts.241", tempFolder)
+
+    @staticmethod
+    def _load_extra_attributes(zf, temp_folder, scenario):
+        zf.extract("exatts.241", temp_folder)
         types = set()
-        with open(tempFolder + "/exatts.241") as reader:
-            reader.readline() #toss first line
+        with open(temp_folder + "/exatts.241") as reader:
+            reader.readline()  # toss first line
             for line in reader.readlines():
-                cells = line.split(',',3)
+                cells = line.split(',', 3)
                 att = scenario.create_extra_attribute(cells[1], cells[0], default_value=float(cells[2]))
-                att.description = cells[3].strip().strip("'") 
-                #strip called twice: once to remove the '\n' character, and once to remove both ' characters
+                att.description = cells[3].strip().strip("'")
+                # strip called twice: once to remove the '\n' character, and once to remove both ' characters
                 types.add(att.type)
-        
+
         return types
-            
 
     @_m.method(return_type=_m.TupleType)
     def percent_completed(self):
         return self.TRACKER.getProgress()
-                
+
     @_m.method(return_type=unicode)
     def tool_run_msg_status(self):
         return self.tool_run_msg
-    
+
     @_m.method(return_type=unicode)
     def get_description_from_file(self):
         if self.NetworkPackageFile:
@@ -461,7 +378,7 @@ class ImportNetworkPackage(_m.Tool()):
                 return _path.splitext(_path.basename(self.NetworkPackageFile))[0]
             else:
                 return self.ScenarioDescription
-    
+
     @_m.method(return_type=unicode)
     def get_file_info(self):
         with self._zipFileMANAGER() as zf:
@@ -470,12 +387,13 @@ class ImportNetworkPackage(_m.Tool()):
                 vf = zf.open('version.txt')
                 version = float(vf.readline())
             else:
-                return """<table border='1' width='90&#37'><tbody><tr><td valign='top'><b>NWP Version:</b> 1.0</td><tr></tbody></table>"""
-            
-            if not 'info.txt' in nl:
-                return "<table border='1' width='90&#37'><tbody><tr><td valign='top'><b>NWP Version:</b> %s</td><tr></tbody></table>" %version
-            
-            
+                return (r"<table border='1' width='90&#37'><tbody><tr><td valign='top'><b>NWP Version:</b> 1.0</td>" +
+                        r"<tr></tbody></table>")
+
+            if 'info.txt' not in nl:
+                return r"<table border='1' width='90&#37'><tbody><tr><td valign='top'><b>NWP Version:</b>" + \
+                       " %s</td><tr></tbody></table>" % version
+
             info = zf.open('info.txt')
             lines = info.readlines()
             '''
@@ -485,29 +403,28 @@ class ImportNetworkPackage(_m.Tool()):
                     Export Date
                     subsequent comment lines]
             '''
-            packageVersion = "<b>NWP Version:</b> %s" %version
-            projectName = "<b>Project:</b> %s" %lines[0].strip()
-            scenarioTitle = "<b>Scenario:</b> %s" %lines[2].strip()
-            exportDate = "<b>Export Date:</b> %s" %lines[3].strip()
-            commentLines = ["<b>User Comments:</b>"] + [l.strip() for l in lines[4:]]
-            htmlLines = [packageVersion, projectName, scenarioTitle, exportDate, ''] + commentLines
-            cell = "<br>".join(htmlLines)
-            
-            return "<table border='1' width='90&#37'><tbody><tr><td valign='top'>%s</td></tr></tbody></table>" %cell
-            
+            package_version = "<b>NWP Version:</b> %s" % version
+            project_name = "<b>Project:</b> %s" % lines[0].strip()
+            scenario_title = "<b>Scenario:</b> %s" % lines[2].strip()
+            export_date = "<b>Export Date:</b> %s" % lines[3].strip()
+            comment_lines = ["<b>User Comments:</b>"] + [l.strip() for l in lines[4:]]
+            html_lines = [package_version, project_name, scenario_title, export_date, ''] + comment_lines
+            cell = "<br>".join(html_lines)
+
+            return "<table border='1' width='90&#37'><tbody><tr><td valign='top'>%s</td></tr></tbody></table>" % cell
+
     @_m.method()
     def set_overwrite_scenario_flag_true(self):
         self.OverwriteScenarioFlag = True
-    
+
     @_m.method()
     def set_overwrite_scenario_flag_false(self):
         self.OverwriteScenarioFlag = False
-    
-    @_m.method(return_type= bool)
+
+    @_m.method(return_type=bool)
     def check_scenario_exists(self):
-        return _bank.scenario(self.ScenarioId) != None
-            
-    @_m.method(return_type= str)
+        return _bank.scenario(self.ScenarioId) is not None
+
+    @_m.method(return_type=str)
     def get_existing_scenario_title(self):
         return _bank.scenario(self.ScenarioId).title
-    


### PR DESCRIPTION
This is in response to Issue #7 .
My latest change to the NWP import/export code adds the ability to save and to load traffic and transit result attributes if they exist. 

The changes have been made in such a way as to be backwards compatible: the NWP reader should have no trouble reading a version without the result tables (it would be as if a scenario was exported without any traffic or transit results).  The new format should also be compatible with the old reader, as it won't know to look for the results tables.

This code has been tested to work with Emme 4.2.7. Note that the Writer now relies on the Pandas package (which wasn't available until 4.2.x). If there are any issues with earlier versions of Emme (which, let's face it, nobody should be using), then the CSV files can be manually written.

I've also refactored the code considerably to clean it up and to follow the standard Python style. In part this should improve readability, but it's mostly because I work in PyCharm nowadays and hate seeing all the little stylistic error crowding my scrollbar.