### PR TITLE
More nwp scenario

### DIFF
--- a/TMGToolbox/src/input_output/import_network_package.py
+++ b/TMGToolbox/src/input_output/import_network_package.py
@@ -126,7 +126,7 @@ class ImportNetworkPackage(_m.Tool()):
         </div>""")
 
         pb.add_text_box(tool_attribute_name='ScenarioId',
-                        size=4,
+                        size=5,
                         title="New Scenario Number",
                         note="Enter a new or existing scenario")
         '''


### PR DESCRIPTION
Emme allows scenario IDs from 1 to 99999 (5 digits). The current NWP tool allows only up to 9999 (4 digits).

Please review for compatibility with different versions of Emme. I only have 4.3.6 installed, and I don't know if this change is backwards compatible. I've also based this PR on the `dev-1.7` branch, which I see is currently the default.