### PR TITLE
Export matrix in the transaction file format required by Emme 4.4

### DIFF
--- a/TMGToolbox/src/XTMF_internal/export_matrix_batch_file.py
+++ b/TMGToolbox/src/XTMF_internal/export_matrix_batch_file.py
@@ -57,7 +57,7 @@ class ExportMatrix(_m.Tool()):
                     raise Exception("No matrix found with id '%s'" %MatrixId)
                 self._tracker.runTool(tool,
                                       export_file=Filename,
-                                      field_separator='TAB',
+                                      field_separator=' ',
                                       matrices=[mtx],
                                       full_matrix_line_format="ONE_ENTRY_PER_LINE",
                                       export_format="PROMPT_DATA_FORMAT",


### PR DESCRIPTION
Change the separator from Tabs to Spaces since Emme 4.4 does not support a matrix transaction file with Tabs.