### PR TITLE
Allow the GUI to create a new matrix before importing binary matrix #50

### DIFF
--- a/TMGToolbox/src/input_output/import_binary_matrix.py
+++ b/TMGToolbox/src/input_output/import_binary_matrix.py
@@ -46,7 +46,6 @@ _MODELLER = _m.Modeller() #Instantiate Modeller once.
 _util = _MODELLER.module('tmg.common.utilities')
 _tmgTPB = _MODELLER.module('tmg.common.TMG_tool_page_builder')
 _bank = _MODELLER.emmebank
-#_CreateMatrixTool = _MODELLER.tool('inro.emme.data.matrix.create_matrix')
 
 ##########################################################################################################
 
@@ -82,8 +81,8 @@ class ImportBinaryMatrix(_m.Tool()):
         
         #---Set the defaults of parameters used by Modeller
         self.Scenario = _MODELLER.scenario #Default is primary scenario
-        #self.NewMatrixName = ""
-        #self.NewMatrixDescription = ""
+        self.NewMatrixName = ""
+        self.NewMatrixDescription = ""
 
     ##########################################################################################################
     #---

--- a/TMGToolbox/src/input_output/import_binary_matrix.py
+++ b/TMGToolbox/src/input_output/import_binary_matrix.py
@@ -46,8 +46,7 @@ _MODELLER = _m.Modeller() #Instantiate Modeller once.
 _util = _MODELLER.module('tmg.common.utilities')
 _tmgTPB = _MODELLER.module('tmg.common.TMG_tool_page_builder')
 _bank = _MODELLER.emmebank
-_CreateMatrixTool = _MODELLER.tool('inro.emme.data.matrix.create_matrix')
-
+#_CreateMatrixTool = _MODELLER.tool('inro.emme.data.matrix.create_matrix')
 
 ##########################################################################################################
 
@@ -83,7 +82,9 @@ class ImportBinaryMatrix(_m.Tool()):
         
         #---Set the defaults of parameters used by Modeller
         self.Scenario = _MODELLER.scenario #Default is primary scenario
-    
+        #self.NewMatrixName = ""
+        #self.NewMatrixDescription = ""
+
     ##########################################################################################################
     #---
     #---MODELLER INTERACE METHODS
@@ -206,11 +207,7 @@ class ImportBinaryMatrix(_m.Tool()):
                               attributes= self._GetAtts()):
 
             if self.MatrixId == None:
-                new_matrix_id = "mf" + str(self.NewMatrixID)
-                new_matrix_name = self.NewMatrixName
-                new_matrix_desc = self.NewMatrixDescription
-                _CreateMatrixTool(matrix_id=new_matrix_id, matrix_name=new_matrix_name, matrix_description=new_matrix_desc)
-                matrix = _util.initializeMatrix(self.NewMatrixID)
+                matrix = _util.initializeMatrix(id=self.NewMatrixID, name = self.NewMatrixName, description = self.NewMatrixDescription)
             else:
                 matrix = _util.initializeMatrix(self.MatrixId)
                 if self.MatrixDescription:

--- a/TMGToolbox/src/input_output/import_binary_matrix.py
+++ b/TMGToolbox/src/input_output/import_binary_matrix.py
@@ -206,7 +206,7 @@ class ImportBinaryMatrix(_m.Tool()):
         with _m.logbook_trace(name="%s v%s" %(self.__class__.__name__, self.version), \
                               attributes= self._GetAtts()):
 
-            if self.MatrixId == None:
+            if self.MatrixId is None:
                 matrix = _util.initializeMatrix(id=self.NewMatrixID, name = self.NewMatrixName, description = self.NewMatrixDescription)
             else:
                 matrix = _util.initializeMatrix(self.MatrixId)

--- a/TMGToolbox/src/input_output/import_binary_matrix.py
+++ b/TMGToolbox/src/input_output/import_binary_matrix.py
@@ -23,7 +23,7 @@ Import Binary Matrix
 
     Authors: pkucirek
 
-    Latest revision by: pkucirek
+    Latest revision by: lunaxi
     
     
     [Description]
@@ -33,6 +33,7 @@ Import Binary Matrix
 '''
     0.0.1 Created on 2014-06-30 by pkucirek
     
+    0.0.3 Modified on 2020-03-09 by lunaxi, allow the GUI to create a matrix first if not existed
 '''
 
 import inro.modeller as _m
@@ -45,12 +46,14 @@ _MODELLER = _m.Modeller() #Instantiate Modeller once.
 _util = _MODELLER.module('tmg.common.utilities')
 _tmgTPB = _MODELLER.module('tmg.common.TMG_tool_page_builder')
 _bank = _MODELLER.emmebank
+_CreateMatrixTool = _MODELLER.tool('inro.emme.data.matrix.create_matrix')
+
 
 ##########################################################################################################
 
 class ImportBinaryMatrix(_m.Tool()):
     
-    version = '0.0.2'
+    version = '0.0.3'
     tool_run_msg = ""
     number_of_tasks = 1 # For progress reporting, enter the integer number of tasks here
     
@@ -69,7 +72,11 @@ class ImportBinaryMatrix(_m.Tool()):
     ImportFile = _m.Attribute(str)
     Scenario = _m.Attribute(_m.InstanceType) # common variable or parameter
     MatrixDescription = _m.Attribute(str)
-    
+
+    NewMatrixID = _m.Attribute(int)
+    NewMatrixName = _m.Attribute(str)
+    NewMatrixDescription = _m.Attribute(str)
+
     def __init__(self):
         #---Init internal variables
         self.TRACKER = _util.ProgressTracker(self.number_of_tasks) #init the ProgressTracker
@@ -88,6 +95,11 @@ class ImportBinaryMatrix(_m.Tool()):
         
         if self.tool_run_msg != "": # to display messages in the page
             pb.tool_run_status(self.tool_run_msg_status)
+
+        pb.add_select_scenario(tool_attribute_name='Scenario',
+                               title='Scenario:',
+                               allow_none=False,
+                               note= "Only required if scenarios have different zone systems.")
         
         pb.add_select_file(tool_attribute_name= 'ImportFile',
                            window_type= 'file',
@@ -97,12 +109,22 @@ class ImportBinaryMatrix(_m.Tool()):
         pb.add_select_matrix(tool_attribute_name= 'MatrixId',
                              id= True,
                              title= "Matrix",
-                             note= "Select an existing matrix in which to save data.")
+                             allow_none=True,
+                             note= "Select an existing matrix to save data, or leave as None and create a new matrix below.")
+
+        pb.add_header("Create a NEW matrix to save data: (Ignore if using existing matrix)")
         
-        pb.add_select_scenario(tool_attribute_name='Scenario',
-                               title='Scenario:',
-                               allow_none=False,
-                               note= "Only required if scenarios have different zone systems.")
+        with pb.add_table(visible_border=False) as t:
+            with t.table_cell():
+                pb.add_text_box(tool_attribute_name='NewMatrixID', 
+                                title='Matrix ID: mf', multi_line=False)
+            with t.table_cell():
+                pb.add_text_box(tool_attribute_name='NewMatrixName', 
+                                title='Matrix Name', multi_line=False)
+            with t.table_cell():
+                pb.add_text_box(tool_attribute_name='NewMatrixDescription', 
+                                title='Description', multi_line=False)
+         
         
         #---JAVASCRIPT
         pb.add_html("""
@@ -182,9 +204,17 @@ class ImportBinaryMatrix(_m.Tool()):
     def _Execute(self):
         with _m.logbook_trace(name="%s v%s" %(self.__class__.__name__, self.version), \
                               attributes= self._GetAtts()):
-            matrix = _util.initializeMatrix(self.MatrixId)
-            if self.MatrixDescription:
-                matrix.description = self.MatrixDescription
+
+            if self.MatrixId == None:
+                new_matrix_id = "mf" + str(self.NewMatrixID)
+                new_matrix_name = self.NewMatrixName
+                new_matrix_desc = self.NewMatrixDescription
+                _CreateMatrixTool(matrix_id=new_matrix_id, matrix_name=new_matrix_name, matrix_description=new_matrix_desc)
+                matrix = _util.initializeMatrix(self.NewMatrixID)
+            else:
+                matrix = _util.initializeMatrix(self.MatrixId)
+                if self.MatrixDescription:
+                    matrix.description = self.MatrixDescription
 
             if str(self.ImportFile)[-2:] == "gz":
                 new_file = 'matrix.mtx'
@@ -238,4 +268,4 @@ class ImportBinaryMatrix(_m.Tool()):
                 "self": self.__MODELLER_NAMESPACE__}
             
         return atts
-        
+


### PR DESCRIPTION
The current tool only supports the importing of an existing matrix. This change will allow the user to create a new matrix and use it for importing. 