### PR TITLE
Update Copy Transit Line tool

### DIFF
--- a/TMGToolbox/src/network_editing/network_comparison/copy_transit_lines.py
+++ b/TMGToolbox/src/network_editing/network_comparison/copy_transit_lines.py
@@ -520,8 +520,8 @@ class CopyTransitLines(_m.Tool()):
             
             vehicleTable = self._LoadVehicleCorrespondenceFile(sourceNetwork, targetNetwork)
             print "Loaded vehicle correspondence table"
-            
-            if self.LinksAllowedForModification is not None:
+
+            if (self.LinksAllowedForModification is not None) and (self.LinksAllowedForModification.isspace() == False):
                 if self.TargetScenario.extra_attribute(self.linkModAttrID) is not None:
                     self.TargetScenario.delete_extra_attribute(self.linkModAttrID)
                 self.TargetScenario.create_extra_attribute('LINK', self.linkModAttrID)

--- a/TMGToolbox/src/network_editing/network_comparison/copy_transit_lines.py
+++ b/TMGToolbox/src/network_editing/network_comparison/copy_transit_lines.py
@@ -159,7 +159,6 @@ class CopyTransitLines(_m.Tool()):
                         size=200, title="Links allowed for modification",
                         note="An expression to select the links in target network that allows for modification. \
                         The mode(s) of the transit lines will be added to these links if they are selected for paths. \
-                        An extra attribute '@link_added_mode' will be created and a value of 1 will be assigned to the links allowed for modification. \
                         Example: i=10999 or j = 10999 and mode=b. More details refer to the 'Network element selectors' section in EMME manual. \
                         <br><br>Leave as Blank to not add any new modes to the links in target network. ",
                         multi_line=True)


### PR DESCRIPTION
Add a function for the user to select from the following:
1) When finding the twin nodes in the target network for the source line, only match with those that have the source line's mode; 
2) Add the source line's mode to the target links if they are selected for the path and allowed for modification (the set of links allowed for modification is specified by the user).