### PR TITLE
refactored assing_v4_boarding penalty

### DIFF
--- a/TMGToolbox/src/assignment/preprocessing/assign_v4_boarding_penalty.py
+++ b/TMGToolbox/src/assignment/preprocessing/assign_v4_boarding_penalty.py
@@ -51,13 +51,15 @@ Assign V4 Boarding Penalties
 
 import inro.modeller as _m
 import traceback as _traceback
-from contextlib import contextmanager
-from contextlib import nested
 from re import split as _regex_split
 _MODELLER = _m.Modeller() #Instantiate Modeller once.
 _util = _MODELLER.module('tmg.common.utilities')
 _tmgTPB = _MODELLER.module('tmg.common.TMG_tool_page_builder')
 NullPointerException = _util.NullPointerException
+# import six library for python2 to python3 conversion
+import six 
+#initalize python3 types
+_util.initalizeModellerTypes(_m)
 
 ##########################################################################################################
 
@@ -309,8 +311,8 @@ class AssignV4BoardingPenalties(_m.Tool()):
     @_m.method(return_type=_m.TupleType)
     def percent_completed(self):
         return self.TRACKER.getProgress()
-                
-    @_m.method(return_type=unicode)
+
+    @_m.method(return_type=six.u)
     def tool_run_msg_status(self):
         return self.tool_run_msg
     

--- a/TMGToolbox/src/common/utilities.py
+++ b/TMGToolbox/src/common/utilities.py
@@ -51,6 +51,16 @@ class Face(_m.Tool()):
 
 #-------------------------------------------------------------------------------------------
 
+def initalizeModellerTypes(modeller):
+    """
+    function to initalize the six python3 settings across
+    all tools and libraries
+    """
+    if six.PY3:
+        modeller.InstanceType = object
+        modeller.TupleType = object
+        modeller.ListType = list
+
 def formatReverseStack():
     eType, eVal, eTb = _sys.exc_info()
     stackList = _tb.extract_tb(eTb)


### PR DESCRIPTION
created a new utility function to initialize the modeller types for python 3
fixed method outputs to be unicode for some functions
successfully tested tools works in both emme 4.43 and 4.6 gui