### PR TITLE
refactored assignment road toll files and export screenline results

### DIFF
--- a/TMGToolbox/src/analysis/traffic/export_screenline_results.py
+++ b/TMGToolbox/src/analysis/traffic/export_screenline_results.py
@@ -194,7 +194,7 @@ class ExportScreenlineResults(_m.Tool()):
         if self.AlternateFlagAttribute: atts.append(self.AlternateFlagAttribute)
         
         countposts = set()
-        for linkId, attributes in _util.fastLoadLinkAttributes(self.Scenario, atts).iteritems():
+        for linkId, attributes in six.iteritems(_util.fastLoadLinkAttributes(self.Scenario, atts)):
             post1 = attributes[self.CountpostFlagAttribute]
             post2 = 0
             if self.AlternateFlagAttribute: post2 = attributes[self.AlternateFlagAttribute]
@@ -219,7 +219,7 @@ class ExportScreenlineResults(_m.Tool()):
             except Exception as e:
                 return "Error while parsing screenline defintion file: %s" %e
                     
-        for screenlineID, stations in screenlines.iteritems():
+        for screenlineID, stations in six.iteritems(screenlines):
             nStations = len(stations)
             nMissing = 0
             for station in stations:
@@ -347,7 +347,7 @@ class ExportScreenlineResults(_m.Tool()):
         with open(self.ExportFile, 'w') as writer:
             writer.write("Screenline,nStations,nMissing,AutoVolume,AdditionalVolume")
             
-            orderedLines = [item for item in screenlines.iteritems()]
+            orderedLines = [item for item in six.iteritems(screenlines)]
             orderedLines.sort()
             
             for screenlineID, stations in orderedLines:

--- a/TMGToolbox/src/assignment/road/tolled/Toll_Based_Road_Assignment.py
+++ b/TMGToolbox/src/assignment/road/tolled/Toll_Based_Road_Assignment.py
@@ -62,12 +62,15 @@ import inro.modeller as _m
 import traceback as _traceback
 import multiprocessing
 from contextlib import contextmanager
-from contextlib import nested
 _MODELLER = _m.Modeller() #Instantiate Modeller once.
 _util = _MODELLER.module('tmg.common.utilities')
 _tmgTPB = _MODELLER.module('tmg.common.TMG_tool_page_builder')
 NullPointerException = _util.NullPointerException
 EMME_VERSION = _util.getEmmeVersion(float)
+# import six library for python2 to python3 conversion
+import six 
+# initalize python3 types
+_util.initalizeModellerTypes(_m)
 
 ##########################################################################################################
 
@@ -360,7 +363,7 @@ class TollBasedRoadAssignment(_m.Tool()):
         with _m.logbook_trace(name="%s (%s v%s)" %(self.RunTitle, self.__class__.__name__, self.version),
                                      attributes=self._getAtts()):
             
-            print "Starting Road Assignment"
+            print("Starting Road Assignment")
             self._tracker.reset()
             
             if EMME_VERSION < 4:
@@ -380,8 +383,7 @@ class TollBasedRoadAssignment(_m.Tool()):
             self._initOutputMatrices()
             self._tracker.completeSubtask()
             
-            with nested(self._costAttributeMANAGER(), self._tollAttributeMANAGER())\
-                    as (costAttribute, tollAttribute): 
+            with self._costAttributeMANAGER() as costAttribute, self._tollAttributeMANAGER() as tollAttribute: 
                 with _util.tempMatrixMANAGER(description="Peak hour matrix") as peakHourMatrix:
                     
                     with _m.logbook_trace("Calculating link costs"):
@@ -406,7 +408,7 @@ class TollBasedRoadAssignment(_m.Tool()):
                     self._tracker.completeTask()
                     
                     with _m.logbook_trace("Running primary road assignment."):
-                        print "Running primary road assignment"
+                        print("Running primary road assignment")
                         
                         if self.SOLAFlag:
                             spec = self._getPrimarySOLASpec(peakHourMatrix.id, tollAttribute.id, appliedTollFactor)
@@ -435,15 +437,15 @@ class TollBasedRoadAssignment(_m.Tool()):
                         else:
                             val = 'undefined'
                         
-                        print "Primary assignment complete at %s iterations" %number
-                        print "Stopping criterion was %s with a value of %s." %(stoppingCriterion, val)
+                        print("Primary assignment complete at %s iterations" %number)
+                        print("Stopping criterion was %s with a value of %s." %(stoppingCriterion, val))
                     
                     self._tracker.startProcess(3)
                     with self._AoNScenarioMANAGER() as allOrNothingScenario:
                         self._tracker.completeSubtask
                         
                         with _m.logbook_trace("All or nothing assignment to recover costs:"):
-                            print "Running all-or-nothing assignment to recover costs."
+                            print("Running all-or-nothing assignment to recover costs.")
                             
                             with _m.logbook_trace("Copying auto times into UL2"):
                                 networkCalculationTool(self._getSaveAutoTimesSpec(), scenario=allOrNothingScenario)
@@ -464,7 +466,7 @@ class TollBasedRoadAssignment(_m.Tool()):
                                 
                                 self._tracker.runTool(trafficAssignmentTool,
                                                       spec, scenario= allOrNothingScenario)
-        print "Road Assignment complete."
+        print("Road Assignment complete.")
 
     ##########################################################################################################
 
@@ -929,7 +931,7 @@ class TollBasedRoadAssignment(_m.Tool()):
     def percent_completed(self):
         return self._tracker.getProgress()
     
-    @_m.method(return_type=unicode)
+    @_m.method(return_type=six.u)
     def tool_run_msg_status(self):
         return self.tool_run_msg
     

--- a/TMGToolbox/src/assignment/road/tolled/toll_attribute.py
+++ b/TMGToolbox/src/assignment/road/tolled/toll_attribute.py
@@ -67,11 +67,15 @@ import inro.modeller as _m
 import traceback as _traceback
 import multiprocessing
 from contextlib import contextmanager
-from contextlib import nested
 _MODELLER = _m.Modeller() #Instantiate Modeller once.
 _util = _MODELLER.module('tmg.common.utilities')
 _tmgTPB = _MODELLER.module('tmg.common.TMG_tool_page_builder')
 EMME_VERSION = _util.getEmmeVersion(float)
+
+# import six library for python2 to python3 conversion
+import six 
+# initalize python3 types
+_util.initalizeModellerTypes(_m)
 
 ##########################################################################################################
 
@@ -338,7 +342,7 @@ class TollBasedRoadAssignment(_m.Tool()):
     def __call__(self, xtmf_ScenarioNumber, xtmf_DemandMatrixNumber, TimesMatrixId, CostMatrixId, TollsMatrixId,
                  PeakHourFactor, LinkCost, TollCost, TollWeight, Iterations, rGap, brGap, normGap, PerformanceFlag,
                  RunTitle, LinkTollAttributeId, SOLAFlag):
-        print "STARTING"
+        print("STARTING")
         #---1 Set up Scenario
         self.Scenario = _m.Modeller().emmebank.scenario(xtmf_ScenarioNumber)
         if (self.Scenario is None):
@@ -378,7 +382,7 @@ class TollBasedRoadAssignment(_m.Tool()):
         try:
             with manager as self.DemandMatrix:
                 
-                print "Running Auto Assignment"
+                print("Running Auto Assignment")
                 self._execute()
         except Exception as e:
             raise Exception(_util.formatReverseStack())
@@ -391,7 +395,7 @@ class TollBasedRoadAssignment(_m.Tool()):
         with _m.logbook_trace(name="%s (%s v%s)" %(self.RunTitle, self.__class__.__name__, self.version),
                                      attributes=self._getAtts()):
             
-            print "Starting Road Assignment"
+            print("Starting Road Assignment")
             self._tracker.reset()
             
             if EMME_VERSION < 4:
@@ -427,7 +431,7 @@ class TollBasedRoadAssignment(_m.Tool()):
                     self._tracker.completeTask()
                     
                     with _m.logbook_trace("Running primary road assignment."):
-                        print "Running primary road assignment"
+                        print("Running primary road assignment")
                         
                         if self.SOLAFlag:
                             spec = self._getPrimarySOLASpec(peakHourMatrix.id, appliedTollFactor)
@@ -456,15 +460,15 @@ class TollBasedRoadAssignment(_m.Tool()):
                         else:
                             val = 'undefined'
                         
-                        print "Primary assignment complete at %s iterations" %number
-                        print "Stopping criterion was %s with a value of %s." %(stoppingCriterion, val)
+                        print("Primary assignment complete at %s iterations" %number)
+                        print("Stopping criterion was %s with a value of %s." %(stoppingCriterion, val))
                     
                     self._tracker.startProcess(3)
                     with self._AoNScenarioMANAGER() as allOrNothingScenario:
                         self._tracker.completeSubtask
                         
                         with _m.logbook_trace("All or nothing assignment to recover costs:"):
-                            print "Running all-or-nothing assignment to recover costs."
+                            print("Running all-or-nothing assignment to recover costs.")
                             
                             with _m.logbook_trace("Copying auto times into UL2"):
                                 networkCalculationTool(self._getSaveAutoTimesSpec(), scenario=allOrNothingScenario)
@@ -485,7 +489,7 @@ class TollBasedRoadAssignment(_m.Tool()):
                                 
                                 self._tracker.runTool(trafficAssignmentTool,
                                                       spec, scenario= allOrNothingScenario)
-        print "Road Assignment complete."
+        print("Road Assignment complete.")
                                  
 
     ##########################################################################################################
@@ -904,11 +908,11 @@ class TollBasedRoadAssignment(_m.Tool()):
     def percent_completed(self):
         return self._tracker.getProgress()
     
-    @_m.method(return_type=unicode)
+    @_m.method(return_type=six.u)
     def tool_run_msg_status(self):
         return self.tool_run_msg
     
-    @_m.method(return_type=unicode)
+    @_m.method(return_type=six.u)
     def _GetSelectAttributeOptionsHTML(self):
         list = []
         


### PR DESCRIPTION
fixed the iteritems issue inside export screenline file
for the toll files fixed print statements and unicode, also replaced nested using with statement. Ran both toll tools successfully in emme 4.6