### PR TITLE
refactored estimate_transit_operating_costs

### DIFF
--- a/TMGToolbox/src/analysis/transit/estimate_transit_operating_costs.py
+++ b/TMGToolbox/src/analysis/transit/estimate_transit_operating_costs.py
@@ -36,7 +36,10 @@ import datetime
 import math
 _MODELLER = _m.Modeller()
 _util = _MODELLER.module('tmg.common.utilities')
-
+# import six library for python2 to python3 conversion
+import six 
+# initalize python3 types
+_util.initalizeModellerTypes(_m)
 #######################################################################################################
 
 


### PR DESCRIPTION
added the six library to resolve the instancetype error issue preventing the tool from loading in the emme gui,
ToDo: need to build the Cost Parameters File and test the tool in EMME.We have verified the tools do load in emme