### PR TITLE
Fix opening CSV writer in Python3

### DIFF
--- a/TMGToolbox/src/XTMF_internal/return_boardings_multiclass.py
+++ b/TMGToolbox/src/XTMF_internal/return_boardings_multiclass.py
@@ -276,7 +276,7 @@ class ReturnBoardings(_m.Tool()):
             fileName = self.xtmf_OutputDirectory + "\\" + re.sub(removeSpecialString, '', personClass["name"]) + ".csv"
             print(fileName)
             del personClass["name"]
-            with open(fileName, 'wb') as classFile:
+            with open(fileName, 'w', newline='') as classFile:
                 wr = csv.writer(classFile, delimiter = ',', quoting = csv.QUOTE_NONNUMERIC)
                 wr.writerow(['line', 'boardings'])
                 for line in sorted(personClass.items()):

--- a/TMGToolbox/src/XTMF_internal/tmg_transit_assignment_tool.py
+++ b/TMGToolbox/src/XTMF_internal/tmg_transit_assignment_tool.py
@@ -1030,7 +1030,7 @@ class TransitAssignmentTool(_m.Tool()):
 
     def _WriteCSVFiles(self, iteration, network, cngap, crgap, normgapdiff):
         if iteration == 0:
-            with open(self.CSVFile, "wb") as iterationFile:
+            with open(self.CSVFile, "w", newline='') as iterationFile:
                 writer = csv.writer(iterationFile)
                 header = [
                     "iteration",
@@ -1043,7 +1043,7 @@ class TransitAssignmentTool(_m.Tool()):
                     "line speed",
                 ]
                 writer.writerow(header)
-        with open(self.CSVFile, "ab") as iterationFile:
+        with open(self.CSVFile, "a", newline='') as iterationFile:
             writer = csv.writer(iterationFile)
             for line in network.transit_lines():
                 boardings = 0.0

--- a/TMGToolbox/src/analysis/link_specific_volumes.py
+++ b/TMGToolbox/src/analysis/link_specific_volumes.py
@@ -99,7 +99,7 @@ class LinkSpecificVolumes(_m.Tool()):
        
         self._Execute()
 
-        with open(filePath, 'wb') as csvfile:               
+        with open(filePath, 'w', newline='') as csvfile:               
             writer = csv.writer(csvfile, delimiter=',')
             if self.TransitFlag:
                 writer.writerow(["Scenario", "Link Filter", "Auto Volume", "Transit Volume"])

--- a/TMGToolbox/src/analysis/traffic/export_countpost_results_multiclass.py
+++ b/TMGToolbox/src/analysis/traffic/export_countpost_results_multiclass.py
@@ -393,8 +393,8 @@ class ExportCountpostResults(_m.Tool()):
         return lines
     
     def _WriteReport(self, lines):
-        with open(self.ExportFile, 'w') as csv_file:
-            writer = csv.writer(csv_file)
+        with open(self.ExportFile, 'w', newline='') as csv_file:
+            writer = csv.writer(csv_file, delimiter = ',')
             #writer.writerow("Countpost,Link,Auto Volume,Additional Volume,Auto Time")
             #for line in lines:
             #    line = [str(c) for c in line]

--- a/TMGToolbox/src/analysis/transit/export_station_boarding_alighting.py
+++ b/TMGToolbox/src/analysis/transit/export_station_boarding_alighting.py
@@ -256,7 +256,7 @@ class ExtractStationBoardingsAlightings(_m.Tool()):
         return nodeIds
 
     def _OutputResults(self, valueDict):
-        with open(self.ReportFile, 'wb') as csvfile:
+        with open(self.ReportFile, 'w', newline='') as csvfile:
             nodeWrite = csv.writer(csvfile, delimiter = ',')
             nodeWrite.writerow(['node_id', 'label', 'boardings', 'transfer_boardings', 'transfer_alightings', 'alightings'])
             for key, values in sorted(valueDict.iteritems()):

--- a/TMGToolbox/src/analysis/transit/strategy_analysis/extract_link_transfers.py
+++ b/TMGToolbox/src/analysis/transit/strategy_analysis/extract_link_transfers.py
@@ -399,7 +399,7 @@ class ExtractLinkTransfers(_m.Tool()):
 		return spec
 
 	def _WriteResultsToFile(self, results):
-		with open(self.ExportFile, 'wb') as csvfile:
+		with open(self.ExportFile, 'w', newline='') as csvfile:
 			aggWrite = csv.writer(csvfile, delimiter = ',')
 			aggWrite.writerow(['label', 'volume'])
 			for item in results:

--- a/TMGToolbox/src/analysis/transit/strategy_analysis/revenue_calculation.py
+++ b/TMGToolbox/src/analysis/transit/strategy_analysis/revenue_calculation.py
@@ -168,7 +168,7 @@ class RevenueCalculation(_m.Tool()):
             self.filtersToCompute = lineFilters
             self._Execute();
 
-            with open(self.ReportFile, 'w') as csvfile:               
+            with open(self.ReportFile, 'w', newline='') as csvfile:               
                 writer = csv.writer(csvfile, delimiter=',')
                 writer.writerow(["Scenario", "Line Filter", "Revenue"])
                 for scenario in sorted(self.results):
@@ -191,7 +191,7 @@ class RevenueCalculation(_m.Tool()):
        
         self._Execute()
 
-        with open(filePath, 'w') as csvfile:               
+        with open(filePath, 'w', newline='') as csvfile:               
             writer = csv.writer(csvfile, delimiter=',')
             writer.writerow(["Scenario", "Line Filter", "Revenue"])
             for scenario in sorted(self.results):

--- a/TMGToolbox/src/analysis/transit/strategy_analysis/volume_per_operator.py
+++ b/TMGToolbox/src/analysis/transit/strategy_analysis/volume_per_operator.py
@@ -166,7 +166,7 @@ class VolumePerOperator(_m.Tool()):
             self.filtersToCompute = lineFilters
             self._Execute();
             
-        with open(self.ReportFile, 'w') as csvfile:               
+        with open(self.ReportFile, 'w', newline='') as csvfile:               
             writer = csv.writer(csvfile, delimiter=',')
             if self.multiclass == False:
                 writer.writerow(["Scenario", "Line Filter", "Ridership"])

--- a/TMGToolbox/src/network_editing/GTFS_utilities/GTFS_EMME_node_map.py
+++ b/TMGToolbox/src/network_editing/GTFS_utilities/GTFS_EMME_node_map.py
@@ -252,7 +252,7 @@ class GTFStoEmmeMap(_m.Tool()):
                 cleanedNumber = int(nearestNode[0])
                 map.append([stop, cleanedNumber,convertedStops[stop][0],convertedStops[stop][1],nodes[cleanedNumber][0],nodes[cleanedNumber][1]])
 
-        with open(self.MappingFileName, 'w') as csvfile:
+        with open(self.MappingFileName, 'w', newline='') as csvfile:
             mapFile = csv.writer(csvfile, delimiter=',')
             header = ["stopID","emmeID","stop x", "stop y", "node x", "node y"]
             mapFile.writerow(header)

--- a/TMGToolbox/src/network_editing/GTFS_utilities/generate_transit_lines_from_GTFS.py
+++ b/TMGToolbox/src/network_editing/GTFS_utilities/generate_transit_lines_from_GTFS.py
@@ -420,7 +420,7 @@ class GenerateTransitLinesFromGTFS(_m.Tool()):
     
     def _GenerateLines(self, routes, stops2nodes, network, writer):
         #This is the main method
-        with open (self.MappingFileName, 'wb') as csvfile:
+        with open (self.MappingFileName, 'w', newline='') as csvfile:
             csvwriter = csv.writer(csvfile)
             csvwriter.writerow(["tripId", "emmeId"])
 

--- a/TMGToolbox/src/network_editing/line_set_conjoiner.py
+++ b/TMGToolbox/src/network_editing/line_set_conjoiner.py
@@ -409,7 +409,7 @@ class LineSetConjoiner(_m.Tool()):
 
     def _WriteNewServiceTable(self, unchangedSched, modSched, sched, leftover):
         f = ['emme_id', 'trip_depart', 'trip_arrive']
-        with open(self.NewServiceTableFile, 'wb') as csvfile:
+        with open(self.NewServiceTableFile, 'w', newline='') as csvfile:
             tableWrite = csv.writer(csvfile, delimiter = ',')
             tableWrite.writerow(['emme_id', 'trip_depart', 'trip_arrive'])
             fullSched = unchangedSched.copy()

--- a/TMGToolbox/src/network_editing/time_of_day_changes/compute_combined_headways.py
+++ b/TMGToolbox/src/network_editing/time_of_day_changes/compute_combined_headways.py
@@ -203,7 +203,7 @@ class ComputeCombinedHeadways(_m.Tool()):
             if totalHeadway[i] != 0:
                 totalHeadway[i] = 60 / totalHeadway[i] #converts total freq into combined headway
         
-        with open(self.ExportFile, 'wb') as csvfile:
+        with open(self.ExportFile, 'w', newline='') as csvfile:
             hdwWrite = csv.writer(csvfile, delimiter = ',')
             hdwWrite.writerow(['line', 'comb_hdw'])
             for i in range(len(patternList)):

--- a/TMGToolbox/src/network_editing/time_of_day_changes/create_aggregation_selection_file.py
+++ b/TMGToolbox/src/network_editing/time_of_day_changes/create_aggregation_selection_file.py
@@ -260,7 +260,7 @@ class CreateAggregationSelectionFile(_m.Tool()):
             _m.logbook_write(msg)
 
     def _WriteAggSelections(self, network, aggTypeId):
-        with open(self.ExportFile, 'wb') as csvfile:
+        with open(self.ExportFile, 'w', newline='') as csvfile:
             aggWrite = csv.writer(csvfile, delimiter = ',')
             aggWrite.writerow(['emme_id', 'agg_type'])
             for line in network.transit_lines():


### PR DESCRIPTION
Updated all references to writing a CSV file so that the file is opened as a string and the newline character is set to empty to avoid having multiple newlines per row.