### PR TITLE
Fix for Transit Background.

### DIFF
--- a/TMGToolbox/src/XTMF_internal/multi_class_road_assignment.py
+++ b/TMGToolbox/src/XTMF_internal/multi_class_road_assignment.py
@@ -627,7 +627,7 @@ class MultiClassRoadAssignment(_m.Tool()):
         return [process_term(x) for x in range_str.split(',')]
         
     def _getTransitBGSpec(self):
-        ttf_terms = str.join(" + ", ["(ttf >="+str(x[0])+" * ttf <= "+str(x[1])+")" for x in self.on_road_ttfs])
+        ttf_terms = str.join(" + ", ["((ttf >="+str(x[0])+") * (ttf <= "+str(x[1])+"))" for x in self.on_road_ttfs])
         return {
                 "result": "@tvph",
                 "expression": "(60 / hdw) * (vauteq) * ("+ttf_terms+")",


### PR DESCRIPTION
Currently when calculating Background Transit demand in road assignment the calculation ttf >= x * ttf <= y is used.  This was assumed to be parsed as (ttf >= x) * (ttf <= y) in EMME however it was parsed as (ttf >= x * tff) <= y.  This patch makes the first expression explicit.