### PR TITLE
Fix NWP check for Network Field Support

### DIFF
--- a/TMGToolbox/src/input_output/export_network_package.py
+++ b/TMGToolbox/src/input_output/export_network_package.py
@@ -276,7 +276,7 @@ class ExportNetworkPackage(m.Tool()):
     def _batchout_network_fields(self, temp_folder, zf):
         version = _util.getEmmeVersion(returnType=tuple)
         # we only can try to export fields if the EMME version is over 4.3
-        if version >= (4, 3, 0) and len(self.Scenario.network_fields()) > 0:
+        if version >= (4, 4, 0) and len(self.Scenario.network_fields()) > 0:
             tool = mm.tool('inro.emme.data.network_field.export_network_fields')
             tool(network_fields="ALL",
                 export_path=temp_folder,

--- a/TMGToolbox/src/input_output/import_network_package.py
+++ b/TMGToolbox/src/input_output/import_network_package.py
@@ -595,7 +595,7 @@ class ImportNetworkPackage(_m.Tool()):
     @_m.logbook_trace("Reading Network Fields")
     def _batchin_network_fields(self, scenario, temp_folder, zf):
         # We can only load in network fields if the version number is over 4.3
-        if _util.getEmmeVersion(tuple) < (4,3,0):
+        if _util.getEmmeVersion(tuple) < (4,4,0):
             return
         tool = _MODELLER.tool("inro.emme.data.network_field.import_network_fields")
         def read_file_if_exists(zf, folder, file):


### PR DESCRIPTION
Network Fields were not added in EMME 4.3, fixed the version check to only enable support for them in EMME 4.4.