### PR TITLE
Catch Export Network Fields

### DIFF
--- a/TMGToolbox/src/input_output/export_network_package.py
+++ b/TMGToolbox/src/input_output/export_network_package.py
@@ -294,27 +294,32 @@ class ExportNetworkPackage(m.Tool()):
         version = _util.getEmmeVersion(returnType=tuple)
         # we only can try to export fields if the EMME version is over 4.3
         if version >= (4, 4, 0) and len(self.Scenario.network_fields()) > 0:
-            tool = mm.tool('inro.emme.data.network_field.export_network_fields')
-            tool(network_fields="ALL",
-                export_path=temp_folder,
-                field_separator=',',
-                scenario=self.Scenario,
-                export_definitions=True
-                )
-            def write_if_exists(zf, directory_name, local_name, scenario_number):
-                # The scenario number is appended as X_1.csv for scenario 1
-                exported_file = path.join(directory_name, local_name + "_" + str(scenario_number) + ".csv")
-                if path.isfile(exported_file):
-                    zf.write(exported_file, arcname=local_name + ".csv")
-                return
-            scenario = self.Scenario.number
-            write_if_exists(zf, temp_folder, "netfield_links", scenario)
-            write_if_exists(zf, temp_folder, "netfield_modes", scenario)
-            write_if_exists(zf, temp_folder, "netfield_nodes", scenario)
-            write_if_exists(zf, temp_folder, "netfield_segments", scenario)
-            write_if_exists(zf, temp_folder, "netfield_transit_lines", scenario)
-            write_if_exists(zf, temp_folder, "netfield_turns", scenario)
-            write_if_exists(zf, temp_folder, "netfield_vehicles", scenario)
+            try:
+                tool = mm.tool('inro.emme.data.network_field.export_network_fields')
+                tool(network_fields="ALL",
+                    export_path=temp_folder,
+                    field_separator=',',
+                    scenario=self.Scenario,
+                    export_definitions=True
+                    )
+                def write_if_exists(zf, directory_name, local_name, scenario_number):
+                    # The scenario number is appended as X_1.csv for scenario 1
+                    exported_file = path.join(directory_name, local_name + "_" + str(scenario_number) + ".csv")
+                    if path.isfile(exported_file):
+                        zf.write(exported_file, arcname=local_name + ".csv")
+                    return
+                scenario = self.Scenario.number
+                write_if_exists(zf, temp_folder, "netfield_links", scenario)
+                write_if_exists(zf, temp_folder, "netfield_modes", scenario)
+                write_if_exists(zf, temp_folder, "netfield_nodes", scenario)
+                write_if_exists(zf, temp_folder, "netfield_segments", scenario)
+                write_if_exists(zf, temp_folder, "netfield_transit_lines", scenario)
+                write_if_exists(zf, temp_folder, "netfield_turns", scenario)
+                write_if_exists(zf, temp_folder, "netfield_vehicles", scenario)
+            except Exception as e:
+                # If there is no network values, EMME throws an error
+                # We can ignore this error and just continue
+                pass
         return
 
 


### PR DESCRIPTION
If there are network fields defined, but none of them have a value EMME will
throw an exception.  This patch will just catch that error and continue
