### PR TITLE
Update Service Table to work across midnight

### DIFF
--- a/TMGToolbox/src/network_editing/time_of_day_changes/create_transit_time_period.py
+++ b/TMGToolbox/src/network_editing/time_of_day_changes/create_transit_time_period.py
@@ -500,7 +500,11 @@ class CreateTimePeriodNetworks(_m.Tool()):
             
             #Calc line speed
             sumTimes = 0
-            for dep, arr in line.trips: sumTimes += arr - dep
+            for dep, arr in line.trips: 
+                # Deal with the case where the trip crosses midnight
+                if dep > arr:
+                    arr = arr + 24 * 3600.0
+                sumTimes += arr - dep
             avgTime = sumTimes / len(line.trips) / 3600.0 #Convert from seconds to hours
             length = sum([seg.link.length for seg in line.segments()]) #Given in km
             speed = length / avgTime #km/hr


### PR DESCRIPTION
In the current implementation if a bus would arrive after midnight the code will produce a negative travel time
this patch instead adds an extra day worth of time to the arrival time to account for that.
