### PR TITLE
Add support for opening transit scenario files with Byte-Order-Marks

### DIFF
--- a/TMGToolbox/src/XTMF_internal/apply_batch_line_edits.py
+++ b/TMGToolbox/src/XTMF_internal/apply_batch_line_edits.py
@@ -153,7 +153,7 @@ class ApplyBatchLineEdits(_m.Tool()):
         return atts 
 
     def _LoadFile(self, fileName):
-        with open(fileName) as reader:
+        with _util.open_safe_reader(fileName) as reader:
             header = reader.readline()
             cells = header.strip().split(self.COMMA)
             

--- a/TMGToolbox/src/common/utilities.py
+++ b/TMGToolbox/src/common/utilities.py
@@ -32,6 +32,7 @@ import sys as _sys
 import traceback as _tb
 import subprocess as _sp
 import six
+import codecs
 from six.moves import range
 
 if six.PY2:
@@ -1406,3 +1407,19 @@ def open_csv_writer(file_path):
     else:
         with open(file_path, "wb") as csvfile:
             yield csv.writer(csvfile, delimiter=",")
+
+def open_safe_reader(path):
+    """Open a text file for reading with BOM markers removed."""
+    _BOM_ENCODINGS = [
+        (codecs.BOM_UTF32_BE, 'utf-32'),
+        (codecs.BOM_UTF32_LE, 'utf-32'),
+        (codecs.BOM_UTF16_BE, 'utf-16'),
+        (codecs.BOM_UTF16_LE, 'utf-16'),
+        (codecs.BOM_UTF8,     'utf-8-sig'),
+    ]
+    with open(path, 'rb') as f:
+        raw = f.read(4)
+    for bom, encoding in _BOM_ENCODINGS:
+        if raw.startswith(bom):
+            return open(path, encoding=encoding)
+    return open(path, encoding='utf-8')

--- a/TMGToolbox/src/network_editing/time_of_day_changes/create_transit_time_period.py
+++ b/TMGToolbox/src/network_editing/time_of_day_changes/create_transit_time_period.py
@@ -48,6 +48,7 @@ _util = _MODELLER.module('tmg.common.utilities')
 _tmgTPB = _MODELLER.module('tmg.common.TMG_tool_page_builder')
 # import six library for python2 to python3 conversion
 import six 
+import codecs
 # initalize python3 types
 _util.initalizeModellerTypes(_m)
 
@@ -310,6 +311,7 @@ class CreateTimePeriodNetworks(_m.Tool()):
             
         return atts 
     
+    
     def _ParseIntTime(self, i):
         try:
             hours = i / 100
@@ -348,7 +350,7 @@ class CreateTimePeriodNetworks(_m.Tool()):
         badIds = set()
 
         if self.TransitServiceTableFile:
-            with open(self.TransitServiceTableFile) as reader:
+            with _util.open_safe_reader(self.TransitServiceTableFile) as reader:
                 header = reader.readline()
                 cells = header.strip().split(self.COMMA)
             
@@ -386,7 +388,7 @@ class CreateTimePeriodNetworks(_m.Tool()):
         
         badIds = set()
         if self.AggTypeSelectionFile:
-            with open(self.AggTypeSelectionFile) as reader:
+            with _util.open_safe_reader(self.AggTypeSelectionFile) as reader:
                 header = reader.readline()
                 cells = header.strip().split(self.COMMA)
             
@@ -416,7 +418,7 @@ class CreateTimePeriodNetworks(_m.Tool()):
     def _LoadAltFile(self, fileNames):
         altData = {}
         for fileName in fileNames:
-            with open(fileName) as reader:
+            with _util.open_safe_reader(fileName) as reader:
                 header = reader.readline()
                 cells = header.strip().split(self.COMMA)
             
@@ -553,52 +555,3 @@ class CreateTimePeriodNetworks(_m.Tool()):
     @_m.method(return_type=six.text_type)
     def tool_run_msg_status(self):
         return self.tool_run_msg
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    


### PR DESCRIPTION
Currently if you have utf-8 files starting with a BOM (Byte-Order-Mark) it will append that byte-order-mark to the first header leading to the model system crashing.  In this patch we've abstracted out a more reliable loader and implemented it for loading all of the files in FullNetworkSetGenerator.